### PR TITLE
Added error messages on ERC1155 and ERC20

### DIFF
--- a/contracts/token/ERC1155/ERC1155Base.sol
+++ b/contracts/token/ERC1155/ERC1155Base.sol
@@ -280,9 +280,9 @@ abstract contract ERC1155Base is IERC1155, ERC165 {
 
     mapping (uint => mapping (address => uint)) storage balances = ERC1155BaseStorage.layout().balances;
 
-    // TODO: error message
-    // balances[id][sender] = balances[id][sender].sub(amount, 'ERC1155: insufficient balances for transfer');
-    balances[id][sender] -= amount;
+    uint256 senderBalance = balances[id][sender];
+    require(senderBalance >= amount, 'ERC1155: insufficient balances for transfer');
+    balances[id][sender] = senderBalance - amount;
     balances[id][recipient] += amount;
 
     emit TransferSingle(operator, sender, recipient, id, amount);
@@ -337,9 +337,10 @@ abstract contract ERC1155Base is IERC1155, ERC165 {
     for (uint i; i < ids.length; i++) {
       uint token = ids[i];
       uint amount = amounts[i];
-      // TODO: error message
-      // balances[id][sender] = balances[id][sender].sub(amount, 'ERC1155: insufficient balances for transfer');
-      balances[token][sender] -= amount;
+
+      uint256 senderBalance = balances[token][sender];
+      require(senderBalance >= amount, 'ERC1155: insufficient balances for transfer');
+      balances[token][sender] = senderBalance - amount;
       balances[token][recipient] += amount;
     }
 

--- a/contracts/token/ERC1155/ERC1155Base.sol
+++ b/contracts/token/ERC1155/ERC1155Base.sol
@@ -282,7 +282,9 @@ abstract contract ERC1155Base is IERC1155, ERC165 {
 
     uint256 senderBalance = balances[id][sender];
     require(senderBalance >= amount, 'ERC1155: insufficient balances for transfer');
-    balances[id][sender] = senderBalance - amount;
+    unchecked {
+      balances[id][sender] = senderBalance - amount;
+    }
     balances[id][recipient] += amount;
 
     emit TransferSingle(operator, sender, recipient, id, amount);
@@ -340,7 +342,9 @@ abstract contract ERC1155Base is IERC1155, ERC165 {
 
       uint256 senderBalance = balances[token][sender];
       require(senderBalance >= amount, 'ERC1155: insufficient balances for transfer');
-      balances[token][sender] = senderBalance - amount;
+      unchecked {
+        balances[token][sender] = senderBalance - amount;
+      }
       balances[token][recipient] += amount;
     }
 

--- a/contracts/token/ERC20/ERC20Base.sol
+++ b/contracts/token/ERC20/ERC20Base.sol
@@ -38,7 +38,9 @@ abstract contract ERC20Base is IERC20 {
   ) override virtual public returns (bool) {
     uint256 currentAllowance = ERC20BaseStorage.layout().allowances[sender][msg.sender];
     require(currentAllowance >= amount, 'ERC20: transfer amount exceeds allowance');
-    _approve(sender, msg.sender, currentAllowance - amount);
+    unchecked {
+      _approve(sender, msg.sender, currentAllowance - amount);
+    }
     _transfer(sender, recipient, amount);
     return true;
   }
@@ -94,7 +96,9 @@ abstract contract ERC20Base is IERC20 {
     ERC20BaseStorage.Layout storage l = ERC20BaseStorage.layout();
     uint256 senderBalance = l.balances[sender];
     require(senderBalance >= amount, 'ERC20: transfer amount exceeds balance');
-    l.balances[sender] = senderBalance - amount;
+    unchecked {
+      l.balances[sender] = senderBalance - amount;
+    }
     l.balances[recipient] += amount;
 
     emit Transfer(sender, recipient, amount);

--- a/contracts/token/ERC20/ERC20Base.sol
+++ b/contracts/token/ERC20/ERC20Base.sol
@@ -36,13 +36,9 @@ abstract contract ERC20Base is IERC20 {
     address recipient,
     uint amount
   ) override virtual public returns (bool) {
-    _approve(
-      sender,
-      msg.sender,
-      // TODO: error message
-      // ERC20BaseStorage.layout().allowances[sender][msg.sender].sub(amount, 'ERC20: transfer amount exceeds allowance')
-      ERC20BaseStorage.layout().allowances[sender][msg.sender] - amount
-    );
+    uint256 currentAllowance = ERC20BaseStorage.layout().allowances[sender][msg.sender];
+    require(currentAllowance >= amount, 'ERC20: transfer amount exceeds allowance');
+    _approve(sender, msg.sender, currentAllowance - amount);
     _transfer(sender, recipient, amount);
     return true;
   }
@@ -96,9 +92,9 @@ abstract contract ERC20Base is IERC20 {
     _beforeTokenTransfer(sender, recipient, amount);
 
     ERC20BaseStorage.Layout storage l = ERC20BaseStorage.layout();
-    // TODO: error message
-    // l.balances[sender] = l.balances[sender].sub(amount, 'ERC20: transfer amount exceeds balance');
-    l.balances[sender] -= amount;
+    uint256 senderBalance = l.balances[sender];
+    require(senderBalance >= amount, 'ERC20: transfer amount exceeds balance');
+    l.balances[sender] = senderBalance - amount;
     l.balances[recipient] += amount;
 
     emit Transfer(sender, recipient, amount);

--- a/spec/token/ERC1155/ERC1155Base.behavior.js
+++ b/spec/token/ERC1155/ERC1155Base.behavior.js
@@ -149,7 +149,7 @@ const describeBehaviorOfERC1155Base = function ({ deploy, mint, burn }, skips) {
               ethers.utils.randomBytes(0)
             )
           ).to.be.revertedWith(
-            'Transaction reverted and Hardhat couldn\'t infer the reason. Please report this to help us improve Hardhat'
+            'ERC1155: insufficient balances for transfer'
           );
         });
 
@@ -208,7 +208,7 @@ const describeBehaviorOfERC1155Base = function ({ deploy, mint, burn }, skips) {
               ethers.utils.randomBytes(0)
             )
           ).to.be.revertedWith(
-            'Transaction reverted and Hardhat couldn\'t infer the reason. Please report this to help us improve Hardhat'
+            'ERC1155: insufficient balances for transfer'
           );
         });
 

--- a/spec/token/ERC20/ERC20Base.behavior.js
+++ b/spec/token/ERC20/ERC20Base.behavior.js
@@ -87,7 +87,9 @@ const describeBehaviorOfERC20Base = function ({ deploy, supply, mint, burn }, sk
         it('has insufficient balance', async function(){
           const amount = ethers.constants.Two;
 
-          await expect(instance.connect(spender).transfer(holder.address, amount)).to.be.reverted;
+          await expect(instance.connect(spender).transfer(holder.address, amount)).to.be.revertedWith(
+              'ERC20: transfer amount exceeds balance'
+          );
         });
       });
     });
@@ -108,14 +110,18 @@ const describeBehaviorOfERC20Base = function ({ deploy, supply, mint, burn }, sk
         it('has insufficient balance', async function(){
           const amount = ethers.constants.Two;
 
-          await expect(instance.connect(spender).transfer(holder.address, amount)).to.be.reverted;
+          await expect(instance.connect(spender).transfer(holder.address, amount)).to.be.revertedWith(
+              'ERC20: transfer amount exceeds balance'
+          );
         });
 
         it('spender not approved', async function(){
           const amount = ethers.constants.Two;
           await mint(sender.address, amount);
 
-          await expect(instance.connect(spender).transferFrom(sender.address, receiver.address, amount)).to.be.reverted;
+          await expect(instance.connect(spender).transferFrom(sender.address, receiver.address, amount)).to.be.revertedWith(
+              'ERC20: transfer amount exceeds allowance'
+          );
         });
       });
     });

--- a/test/token/ERC1155/ERC1155Base.js
+++ b/test/token/ERC1155/ERC1155Base.js
@@ -568,7 +568,7 @@ describe('ERC1155Base', function () {
               ethers.utils.randomBytes(0)
             )
           ).to.be.revertedWith(
-            'Transaction reverted and Hardhat couldn\'t infer the reason. Please report this to help us improve Hardhat'
+            'ERC1155: insufficient balances for transfer'
           );
         });
       });
@@ -663,7 +663,7 @@ describe('ERC1155Base', function () {
               ethers.utils.randomBytes(0)
             )
           ).to.be.revertedWith(
-            'Transaction reverted and Hardhat couldn\'t infer the reason. Please report this to help us improve Hardhat'
+            'ERC1155: insufficient balances for transfer'
           );
         });
 
@@ -788,7 +788,7 @@ describe('ERC1155Base', function () {
               ethers.utils.randomBytes(0)
             )
           ).to.be.revertedWith(
-            'Transaction reverted and Hardhat couldn\'t infer the reason. Please report this to help us improve Hardhat'
+            'ERC1155: insufficient balances for transfer'
           );
         });
       });
@@ -898,7 +898,7 @@ describe('ERC1155Base', function () {
               ethers.utils.randomBytes(0)
             )
           ).to.be.revertedWith(
-            'Transaction reverted and Hardhat couldn\'t infer the reason. Please report this to help us improve Hardhat'
+            'ERC1155: insufficient balances for transfer'
           );
         });
 


### PR DESCRIPTION
- Added insufficient balance message on ERC1155 
- Added exceeds allowance error message on ERC20

Adds only ~60 gas usage on the function calls, and allows to check for error message when writing tests, to ensure reason of revert