### PR TITLE
misc: optimize gas in EnumerableSet and EnumerableMap

### DIFF
--- a/contracts/utils/EnumerableMap.sol
+++ b/contracts/utils/EnumerableMap.sol
@@ -189,19 +189,18 @@ library EnumerableMap {
         uint256 keyIndex = map._indexes[key];
 
         if (keyIndex != 0) {
-            uint256 index;
             unchecked {
-                index = keyIndex - 1;
+                // don't need to check underflow because valueIndex must > 0.
+                uint256 index = keyIndex - 1;
+                MapEntry storage last = map._entries[map._entries.length - 1];
+
+                // move last entry to now-vacant index
+
+                map._entries[index] = last;
+                map._indexes[last._key] = index + 1;
             }
-            MapEntry storage last = map._entries[map._entries.length - 1];
-
-            // move last entry to now-vacant index
-
-            map._entries[index] = last;
-            map._indexes[last._key] = keyIndex;
 
             // clear last index
-
             map._entries.pop();
             delete map._indexes[key];
 

--- a/contracts/utils/EnumerableMap.sol
+++ b/contracts/utils/EnumerableMap.sol
@@ -189,13 +189,16 @@ library EnumerableMap {
         uint256 keyIndex = map._indexes[key];
 
         if (keyIndex != 0) {
-            uint256 index = keyIndex - 1;
+            uint256 index;
+            unchecked {
+                index = keyIndex - 1;
+            }
             MapEntry storage last = map._entries[map._entries.length - 1];
 
             // move last entry to now-vacant index
 
             map._entries[index] = last;
-            map._indexes[last._key] = index + 1;
+            map._indexes[last._key] = keyIndex;
 
             // clear last index
 

--- a/contracts/utils/EnumerableMap.sol
+++ b/contracts/utils/EnumerableMap.sol
@@ -194,13 +194,11 @@ library EnumerableMap {
 
         if (keyIndex != 0) {
             unchecked {
-                uint256 index = keyIndex - 1;
                 MapEntry storage last = map._entries[map._entries.length - 1];
 
                 // move last entry to now-vacant index
-
-                map._entries[index] = last;
-                map._indexes[last._key] = index + 1;
+                map._entries[keyIndex - 1] = last;
+                map._indexes[last._key] = keyIndex;
             }
 
             // clear last index

--- a/contracts/utils/EnumerableMap.sol
+++ b/contracts/utils/EnumerableMap.sol
@@ -194,7 +194,6 @@ library EnumerableMap {
 
         if (keyIndex != 0) {
             unchecked {
-                // don't need to check underflow because valueIndex must > 0.
                 uint256 index = keyIndex - 1;
                 MapEntry storage last = map._entries[map._entries.length - 1];
 

--- a/contracts/utils/EnumerableMap.sol
+++ b/contracts/utils/EnumerableMap.sol
@@ -165,7 +165,9 @@ library EnumerableMap {
     function _get(Map storage map, bytes32 key) private view returns (bytes32) {
         uint256 keyIndex = map._indexes[key];
         require(keyIndex != 0, 'EnumerableMap: nonexistent key');
-        return map._entries[keyIndex - 1]._value;
+        unchecked {
+            return map._entries[keyIndex - 1]._value;
+        }
     }
 
     function _set(
@@ -180,7 +182,9 @@ library EnumerableMap {
             map._indexes[key] = map._entries.length;
             return true;
         } else {
-            map._entries[keyIndex - 1]._value = value;
+            unchecked {
+                map._entries[keyIndex - 1]._value = value;
+            }
             return false;
         }
     }

--- a/contracts/utils/EnumerableSet.sol
+++ b/contracts/utils/EnumerableSet.sol
@@ -197,7 +197,6 @@ library EnumerableSet {
 
         if (valueIndex != 0) {
             unchecked {
-                // don't need to check underflow because valueIndex must > 0.
                 uint256 index = valueIndex - 1;
 
                 bytes32 last = set._values[set._values.length - 1];

--- a/contracts/utils/EnumerableSet.sol
+++ b/contracts/utils/EnumerableSet.sol
@@ -196,13 +196,16 @@ library EnumerableSet {
         uint256 valueIndex = set._indexes[value];
 
         if (valueIndex != 0) {
-            uint256 index = valueIndex - 1;
+            uint256 index;
+            unchecked {
+                index = valueIndex - 1;
+            }
             bytes32 last = set._values[set._values.length - 1];
 
             // move last value to now-vacant index
 
             set._values[index] = last;
-            set._indexes[last] = index + 1;
+            set._indexes[last] = valueIndex;
 
             // clear last index
 

--- a/contracts/utils/EnumerableSet.sol
+++ b/contracts/utils/EnumerableSet.sol
@@ -196,17 +196,17 @@ library EnumerableSet {
         uint256 valueIndex = set._indexes[value];
 
         if (valueIndex != 0) {
-            uint256 index;
             unchecked {
-                index = valueIndex - 1;
+                // don't need to check underflow because valueIndex must > 0.
+                uint256 index = valueIndex - 1;
+
+                bytes32 last = set._values[set._values.length - 1];
+
+                // move last value to now-vacant index
+
+                set._values[index] = last;
+                set._indexes[last] = index + 1;
             }
-            bytes32 last = set._values[set._values.length - 1];
-
-            // move last value to now-vacant index
-
-            set._values[index] = last;
-            set._indexes[last] = valueIndex;
-
             // clear last index
 
             set._values.pop();

--- a/contracts/utils/EnumerableSet.sol
+++ b/contracts/utils/EnumerableSet.sol
@@ -197,14 +197,12 @@ library EnumerableSet {
 
         if (valueIndex != 0) {
             unchecked {
-                uint256 index = valueIndex - 1;
-
                 bytes32 last = set._values[set._values.length - 1];
 
                 // move last value to now-vacant index
 
-                set._values[index] = last;
-                set._indexes[last] = index + 1;
+                set._values[valueIndex - 1] = last;
+                set._indexes[last] = valueIndex;
             }
             // clear last index
 


### PR DESCRIPTION
## Updates
Main idea: use `unchecked` to avoid duplicate underflow check on `keyIndex - 1` 

## Gas report
according to the gas report, this saves an average of 100~ gas on involved methods. Here are some examples:


| Contract | Method | Avg. gas used before | Avg. gas used after | 
| -------- | -------- | -------- | -------- |
| ERC1155EnumerableMock | __burn | 53484 | 53060 |
| ERC1155EnumerableMock | safeTransferFrom | 136119 | 135589 |
| ERC1155Mock | __burn | 53517 | 53093 |
| ERC1155Mock | safeBatchTransferFrom | 139048 | 138518 |