### PR TITLE
Fix ERC1404 storage location

### DIFF
--- a/contracts/token/ERC1404/ERC1404Mock.sol
+++ b/contracts/token/ERC1404/ERC1404Mock.sol
@@ -3,13 +3,13 @@
 pragma solidity ^0.8.0;
 
 import { ERC1404 } from './ERC1404.sol';
-import { ERC1404Storage } from './base/ERC1404Storage.sol';
+import { ERC1404BaseStorage } from './base/ERC1404BaseStorage.sol';
 
 contract ERC1404Mock is ERC1404 {
-    using ERC1404Storage for ERC1404Storage.Layout;
+    using ERC1404BaseStorage for ERC1404BaseStorage.Layout;
 
     constructor(uint8[] memory errorCodes, string[] memory errorMessages) {
-        ERC1404Storage.layout().setRestrictions(errorCodes, errorMessages);
+        ERC1404BaseStorage.layout().setRestrictions(errorCodes, errorMessages);
     }
 
     function _detectTransferRestriction(

--- a/contracts/token/ERC1404/base/ERC1404BaseInternal.sol
+++ b/contracts/token/ERC1404/base/ERC1404BaseInternal.sol
@@ -2,15 +2,15 @@
 
 pragma solidity ^0.8.0;
 
-import { ERC20Base, ERC20BaseInternal } from '../../ERC20/base/ERC20Base.sol';
+import { ERC20BaseInternal } from '../../ERC20/base/ERC20BaseInternal.sol';
 import { IERC1404 } from '../IERC1404.sol';
-import { ERC1404Storage } from './ERC1404Storage.sol';
+import { ERC1404BaseStorage } from './ERC1404BaseStorage.sol';
 
 /**
  * @title Base ERC1404 internal functions
  */
 abstract contract ERC1404BaseInternal is ERC20BaseInternal {
-    using ERC1404Storage for ERC1404Storage.Layout;
+    using ERC1404BaseStorage for ERC1404BaseStorage.Layout;
 
     function _detectTransferRestriction(
         address from,
@@ -24,7 +24,8 @@ abstract contract ERC1404BaseInternal is ERC20BaseInternal {
         virtual
         returns (string memory)
     {
-        return ERC1404Storage.layout().getRestrictionMessage(restrictionCode);
+        return
+            ERC1404BaseStorage.layout().getRestrictionMessage(restrictionCode);
     }
 
     /**

--- a/contracts/token/ERC1404/base/ERC1404BaseMock.sol
+++ b/contracts/token/ERC1404/base/ERC1404BaseMock.sol
@@ -3,13 +3,13 @@
 pragma solidity ^0.8.0;
 
 import { ERC1404Base } from './ERC1404Base.sol';
-import { ERC1404Storage } from './ERC1404Storage.sol';
+import { ERC1404BaseStorage } from './ERC1404BaseStorage.sol';
 
 contract ERC1404BaseMock is ERC1404Base {
-    using ERC1404Storage for ERC1404Storage.Layout;
+    using ERC1404BaseStorage for ERC1404BaseStorage.Layout;
 
     constructor(uint8[] memory errorCodes, string[] memory errorMessages) {
-        ERC1404Storage.layout().setRestrictions(errorCodes, errorMessages);
+        ERC1404BaseStorage.layout().setRestrictions(errorCodes, errorMessages);
     }
 
     function _detectTransferRestriction(

--- a/contracts/token/ERC1404/base/ERC1404BaseStorage.sol
+++ b/contracts/token/ERC1404/base/ERC1404BaseStorage.sol
@@ -2,13 +2,13 @@
 
 pragma solidity ^0.8.0;
 
-library ERC1404Storage {
+library ERC1404BaseStorage {
     struct Layout {
         mapping(uint8 => string) restrictions;
     }
 
     bytes32 internal constant STORAGE_SLOT =
-        keccak256('solidstate.contracts.storage.ERC1404');
+        keccak256('solidstate.contracts.storage.ERC1404Base');
 
     function layout() internal pure returns (Layout storage l) {
         bytes32 slot = STORAGE_SLOT;


### PR DESCRIPTION
The ERC1404 storage location and storage library name do not conform to standards set by `ERC20Base`, etc.

@NouDaimon Would you take a quick look at the other storage libraries and make sure I didn't miss any more?