### PR TITLE
misc: remove specific revert message from spec

### DIFF
--- a/spec/multisig/ECDSAMultisigWallet.behavior.ts
+++ b/spec/multisig/ECDSAMultisigWallet.behavior.ts
@@ -447,7 +447,7 @@ export function describeBehaviorOfECDSAMultisigWallet(
                   value,
                 },
               ),
-            ).to.be.revertedWith('Mock on the method is not initialized');
+            ).to.be.reverted;
           });
 
           it('quorum is not reached', async function () {

--- a/spec/proxy/diamond/Diamond.behavior.ts
+++ b/spec/proxy/diamond/Diamond.behavior.ts
@@ -118,7 +118,7 @@ export function describeBehaviorOfDiamond(
             to: instance.address,
             data: ethers.utils.randomBytes(4),
           }),
-        ).to.be.revertedWith('Mock on the method is not initialized');
+        ).to.be.reverted;
       });
 
       describe('reverts if', function () {
@@ -168,9 +168,8 @@ export function describeBehaviorOfDiamond(
           expectedSelectors.push(selector);
 
           // call reverts, but with mock-specific message
-          await expect(
-            owner.call({ to: instance.address, data: selector }),
-          ).to.be.revertedWith('Mock on the method is not initialized');
+          await expect(owner.call({ to: instance.address, data: selector })).to
+            .be.reverted;
 
           expect(await instance.callStatic['facets()']()).to.have.deep.members([
             ...facetCuts.map((fc) => [fc.target, fc.selectors]),
@@ -223,9 +222,8 @@ export function describeBehaviorOfDiamond(
             );
 
             // call reverts, but with mock-specific message
-            await expect(
-              owner.call({ to: instance.address, data: last }),
-            ).to.be.revertedWith('Mock on the method is not initialized');
+            await expect(owner.call({ to: instance.address, data: last })).to.be
+              .reverted;
           }
 
           await expect(
@@ -287,9 +285,8 @@ export function describeBehaviorOfDiamond(
             );
 
             // call reverts, but with mock-specific message
-            await expect(
-              owner.call({ to: instance.address, data: last }),
-            ).to.be.revertedWith('Mock on the method is not initialized');
+            await expect(owner.call({ to: instance.address, data: last })).to.be
+              .reverted;
           }
 
           await expect(
@@ -351,9 +348,8 @@ export function describeBehaviorOfDiamond(
             );
 
             // call reverts, but with mock-specific message
-            await expect(
-              owner.call({ to: instance.address, data: last }),
-            ).to.be.revertedWith('Mock on the method is not initialized');
+            await expect(owner.call({ to: instance.address, data: last })).to.be
+              .reverted;
           }
 
           await expect(

--- a/spec/proxy/diamond/DiamondCuttable.behavior.ts
+++ b/spec/proxy/diamond/DiamondCuttable.behavior.ts
@@ -475,7 +475,7 @@ export function describeBehaviorOfDiamondCuttable(
         it('initialization function reverts', async function () {
           await expect(
             instance.connect(owner).diamondCut([], facet.address, '0x01'),
-          ).to.be.revertedWith('Mock on the method is not initialized');
+          ).to.be.reverted;
         });
       });
     });

--- a/spec/proxy/diamond/DiamondCuttable.behavior.ts
+++ b/spec/proxy/diamond/DiamondCuttable.behavior.ts
@@ -113,9 +113,7 @@ export function describeBehaviorOfDiamondCuttable(
 
           for (let fn of functions) {
             // call reverts, but with mock-specific message
-            await expect(contract.callStatic[fn]()).to.be.revertedWith(
-              'Mock on the method is not initialized',
-            );
+            await expect(contract.callStatic[fn]()).to.be.reverted;
           }
         });
 
@@ -176,9 +174,7 @@ export function describeBehaviorOfDiamondCuttable(
 
           for (let fn of functions) {
             // call reverts, but with mock-specific message
-            await expect(contract.callStatic[fn]()).to.be.revertedWith(
-              'Mock on the method is not initialized',
-            );
+            await expect(contract.callStatic[fn]()).to.be.reverted;
           }
 
           const facetReplacement = await deployMockContract(owner, abi);
@@ -197,9 +193,7 @@ export function describeBehaviorOfDiamondCuttable(
 
           for (let fn of functions) {
             // call reverts, but with mock-specific message
-            await expect(contract.callStatic[fn]()).to.be.revertedWith(
-              'Mock on the method is not initialized',
-            );
+            await expect(contract.callStatic[fn]()).to.be.reverted;
           }
         });
 
@@ -316,9 +310,7 @@ export function describeBehaviorOfDiamondCuttable(
 
           for (let fn of functions) {
             // call reverts, but with mock-specific message
-            await expect(contract.callStatic[fn]()).to.be.revertedWith(
-              'Mock on the method is not initialized',
-            );
+            await expect(contract.callStatic[fn]()).to.be.reverted;
           }
 
           await instance

--- a/spec/proxy/upgradeable/UpgradeableProxyOwnable.behavior.ts
+++ b/spec/proxy/upgradeable/UpgradeableProxyOwnable.behavior.ts
@@ -57,16 +57,14 @@ export function describeBehaviorOfUpgradeableProxyOwnable(
 
         const contract = new ethers.Contract(instance.address, abi, owner);
 
-        await expect(
-          contract.callStatic[implementationFunction](),
-        ).not.to.be.revertedWith('Mock on the method is not initialized');
+        await expect(contract.callStatic[implementationFunction]()).not.to.be
+          .reverted;
 
         await instance.connect(owner).setImplementation(implementation.address);
 
         // call reverts, but with mock-specific message
-        await expect(
-          contract.callStatic[implementationFunction](),
-        ).to.be.revertedWith('Mock on the method is not initialized');
+        await expect(contract.callStatic[implementationFunction]()).to.be
+          .reverted;
       });
 
       describe('reverts if', () => {

--- a/spec/token/ERC1155/ERC1155Base.behavior.ts
+++ b/spec/token/ERC1155/ERC1155Base.behavior.ts
@@ -259,7 +259,7 @@ export function describeBehaviorOfERC1155Base(
                 ethers.constants.Zero,
                 ethers.utils.randomBytes(0),
               ),
-          ).to.be.revertedWith('Mock on the method is not initialized');
+          ).to.be.reverted;
         });
 
         it('receiver rejects transfer', async function () {
@@ -375,7 +375,7 @@ export function describeBehaviorOfERC1155Base(
                 [],
                 ethers.utils.randomBytes(0),
               ),
-          ).to.be.revertedWith('Mock on the method is not initialized');
+          ).to.be.reverted;
         });
 
         it('receiver rejects transfer', async function () {


### PR DESCRIPTION
## TLDR
* The hardcoded `revertWith()` message is causing inheriting project tests to fail because of the instance passed in might not revert with the same message