### PR TITLE
Link to `typechain-types` via virtual yarn package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ yarn.lock
 yarn-error.log
 lerna-debug.log
 
-typechain/
+typechain-types/
 dist/
 
 artifacts/

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -39,6 +39,5 @@ export default {
 
   typechain: {
     alwaysGenerateOverloads: true,
-    outDir: 'typechain',
   },
 };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "hardhat compile && lerna run tsc",
     "prepare": "husky install",
     "prettier": "prettier --write --ignore-path .gitignore .",
-    "upgrade-dependencies": "yarn-up -e '@solidstate/library,@solidstate/spec' && yarn upgrade"
+    "upgrade-dependencies": "yarn-up -e '@solidstate/library,@solidstate/spec,@solidstate/typechain-types' && yarn upgrade"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.5",
@@ -16,6 +16,7 @@
     "@solidstate/hardhat-4byte-uploader": "^1.0.2",
     "@solidstate/library": "link:lib",
     "@solidstate/spec": "link:spec",
+    "@solidstate/typechain-types": "link:typechain-types",
     "@trivago/prettier-plugin-sort-imports": "^3.2.0",
     "@typechain/ethers-v5": "^10.0.0",
     "@typechain/hardhat": "^6.0.0",

--- a/spec/access/Ownable.behavior.ts
+++ b/spec/access/Ownable.behavior.ts
@@ -1,6 +1,6 @@
-import { Ownable } from '../../typechain';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeFilter } from '@solidstate/library';
+import { Ownable } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 

--- a/spec/access/SafeOwnable.behavior.ts
+++ b/spec/access/SafeOwnable.behavior.ts
@@ -1,7 +1,7 @@
-import { SafeOwnable } from '../../typechain';
 import { describeBehaviorOfOwnable } from './Ownable.behavior';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeFilter } from '@solidstate/library';
+import { SafeOwnable } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'ethers';
 

--- a/spec/factory/MetamorphicFactory.behavior.ts
+++ b/spec/factory/MetamorphicFactory.behavior.ts
@@ -1,6 +1,6 @@
-import { MetamorphicFactory } from '../../typechain';
 import { describeBehaviorOfFactory } from './Factory.behavior';
 import { describeFilter } from '@solidstate/library';
+import { MetamorphicFactory } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 

--- a/spec/introspection/ERC165.behavior.ts
+++ b/spec/introspection/ERC165.behavior.ts
@@ -1,5 +1,5 @@
-import { ERC165 } from '../../typechain';
 import { describeFilter } from '@solidstate/library';
+import { ERC165 } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 
 interface ERC165BehaviorArgs {

--- a/spec/multisig/ECDSAMultisigWallet.behavior.ts
+++ b/spec/multisig/ECDSAMultisigWallet.behavior.ts
@@ -1,6 +1,6 @@
-import { ECDSAMultisigWallet } from '../../typechain';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeFilter, signData } from '@solidstate/library';
+import { ECDSAMultisigWallet } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { deployMockContract } from 'ethereum-waffle';
 import { BigNumber, BigNumberish, BytesLike } from 'ethers';

--- a/spec/proxy/Proxy.behavior.ts
+++ b/spec/proxy/Proxy.behavior.ts
@@ -1,5 +1,5 @@
-import { Proxy } from '../../typechain';
 import { describeFilter } from '@solidstate/library';
+import { Proxy } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 

--- a/spec/proxy/diamond/Diamond.behavior.ts
+++ b/spec/proxy/diamond/Diamond.behavior.ts
@@ -1,10 +1,10 @@
-import { Diamond } from '../../../typechain';
 import { describeBehaviorOfSafeOwnable } from '../../access';
 import { describeBehaviorOfERC165 } from '../../introspection';
 import { describeBehaviorOfDiamondCuttable } from './DiamondCuttable.behavior';
 import { describeBehaviorOfDiamondLoupe } from './DiamondLoupe.behavior';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeFilter } from '@solidstate/library';
+import { Diamond } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { deployMockContract, MockContract } from 'ethereum-waffle';
 import { ethers } from 'hardhat';

--- a/spec/proxy/diamond/DiamondBase.behavior.ts
+++ b/spec/proxy/diamond/DiamondBase.behavior.ts
@@ -1,5 +1,5 @@
-import { DiamondBase } from '../../../typechain';
 import { describeFilter } from '@solidstate/library';
+import { DiamondBase } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 

--- a/spec/proxy/diamond/DiamondCuttable.behavior.ts
+++ b/spec/proxy/diamond/DiamondCuttable.behavior.ts
@@ -1,7 +1,7 @@
-import { DiamondCuttable } from '../../../typechain';
 import { describeBehaviorOfERC165 } from '../../introspection';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeFilter } from '@solidstate/library';
+import { DiamondCuttable } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { deployMockContract } from 'ethereum-waffle';
 import { ethers } from 'hardhat';

--- a/spec/proxy/diamond/DiamondLoupe.behavior.ts
+++ b/spec/proxy/diamond/DiamondLoupe.behavior.ts
@@ -1,6 +1,6 @@
-import { DiamondLoupe } from '../../../typechain';
 import { describeBehaviorOfERC165 } from '../../introspection';
 import { describeFilter } from '@solidstate/library';
+import { DiamondLoupe } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 

--- a/spec/proxy/managed/ManagedProxy.behavior.ts
+++ b/spec/proxy/managed/ManagedProxy.behavior.ts
@@ -1,6 +1,6 @@
-import { ManagedProxy } from '../../../typechain';
 import { describeBehaviorOfProxy } from '../Proxy.behavior';
 import { describeFilter } from '@solidstate/library';
+import { ManagedProxy } from '@solidstate/typechain-types';
 
 interface ManagedProxyBehaviorArgs {
   deploy: () => Promise<ManagedProxy>;

--- a/spec/proxy/managed/ManagedProxyOwnable.behavior.ts
+++ b/spec/proxy/managed/ManagedProxyOwnable.behavior.ts
@@ -1,6 +1,6 @@
-import { ManagedProxyOwnable } from '../../../typechain';
 import { describeBehaviorOfManagedProxy } from './ManagedProxy.behavior';
 import { describeFilter } from '@solidstate/library';
+import { ManagedProxyOwnable } from '@solidstate/typechain-types';
 
 interface ManagedProxyOwnableBehaviorArgs {
   deploy: () => Promise<ManagedProxyOwnable>;

--- a/spec/proxy/upgradeable/UpgradeableProxy.behavior.ts
+++ b/spec/proxy/upgradeable/UpgradeableProxy.behavior.ts
@@ -1,6 +1,6 @@
-import { UpgradeableProxy } from '../../../typechain';
 import { describeBehaviorOfProxy } from '../Proxy.behavior';
 import { describeFilter } from '@solidstate/library';
+import { UpgradeableProxy } from '@solidstate/typechain-types';
 
 interface UpgradeableProxyBehaviorArgs {
   deploy: () => Promise<UpgradeableProxy>;

--- a/spec/proxy/upgradeable/UpgradeableProxyOwnable.behavior.ts
+++ b/spec/proxy/upgradeable/UpgradeableProxyOwnable.behavior.ts
@@ -1,7 +1,7 @@
-import { UpgradeableProxyOwnable } from '../../../typechain';
 import { describeBehaviorOfUpgradeableProxy } from './UpgradeableProxy.behavior';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeFilter } from '@solidstate/library';
+import { UpgradeableProxyOwnable } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { deployMockContract } from 'ethereum-waffle';
 import { ethers } from 'hardhat';

--- a/spec/signature/ERC1271Base.behavior.ts
+++ b/spec/signature/ERC1271Base.behavior.ts
@@ -1,5 +1,5 @@
-import { ERC1271Base } from '../../typechain';
 import { describeFilter } from '@solidstate/library';
+import { ERC1271Base } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 
 interface ERC1271BaseBehaviorArgs {

--- a/spec/signature/ERC1271Ownable.behavior.ts
+++ b/spec/signature/ERC1271Ownable.behavior.ts
@@ -1,7 +1,7 @@
-import { ERC1271Ownable } from '../../typechain';
 import { describeBehaviorOfERC1271Base } from './ERC1271Base.behavior';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeFilter } from '@solidstate/library';
+import { ERC1271Ownable } from '@solidstate/typechain-types';
 import { ethers } from 'hardhat';
 
 interface ERC1271OwnableBehaviorArgs {

--- a/spec/signature/ERC1271Stored.behavior.ts
+++ b/spec/signature/ERC1271Stored.behavior.ts
@@ -1,6 +1,6 @@
-import { ERC1271Stored } from '../../typechain';
 import { describeBehaviorOfERC1271Base } from './ERC1271Base.behavior';
 import { describeFilter } from '@solidstate/library';
+import { ERC1271Stored } from '@solidstate/typechain-types';
 import { ethers } from 'hardhat';
 
 interface ERC1271OwnableBehaviorArgs {

--- a/spec/token/ERC1155/ERC1155.behavior.ts
+++ b/spec/token/ERC1155/ERC1155.behavior.ts
@@ -1,8 +1,8 @@
-import { ERC1155 } from '../../../typechain';
 import { describeBehaviorOfERC1155Base } from './ERC1155Base.behavior';
 import { describeBehaviorOfERC1155Enumerable } from './ERC1155Enumerable.behavior';
 import { describeBehaviorOfERC1155Metadata } from './ERC1155Metadata.behavior';
 import { describeFilter } from '@solidstate/library';
+import { ERC1155 } from '@solidstate/typechain-types';
 import { BigNumber, ContractTransaction } from 'ethers';
 
 interface ERC1155BehaviorArgs {

--- a/spec/token/ERC1155/ERC1155Base.behavior.ts
+++ b/spec/token/ERC1155/ERC1155Base.behavior.ts
@@ -1,7 +1,7 @@
-import { ERC1155Base } from '../../../typechain';
 import { describeBehaviorOfERC165 } from '../../introspection';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeFilter } from '@solidstate/library';
+import { ERC1155Base } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { deployMockContract } from 'ethereum-waffle';
 import { BigNumber, ContractTransaction } from 'ethers';

--- a/spec/token/ERC1155/ERC1155Enumerable.behavior.ts
+++ b/spec/token/ERC1155/ERC1155Enumerable.behavior.ts
@@ -1,6 +1,6 @@
-import { ERC1155Enumerable } from '../../../typechain';
 import { describeBehaviorOfERC1155Base } from './ERC1155Base.behavior';
 import { describeFilter } from '@solidstate/library';
+import { ERC1155Enumerable } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { BigNumber, ContractTransaction } from 'ethers';
 import { ethers } from 'hardhat';

--- a/spec/token/ERC1155/ERC1155Metadata.behavior.ts
+++ b/spec/token/ERC1155/ERC1155Metadata.behavior.ts
@@ -1,5 +1,5 @@
-import { ERC1155Metadata } from '../../../typechain';
 import { describeFilter } from '@solidstate/library';
+import { ERC1155Metadata } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 
 interface ERC1155MetadataBehaviorArgs {

--- a/spec/token/ERC1404/ERC1404.behavior.ts
+++ b/spec/token/ERC1404/ERC1404.behavior.ts
@@ -1,7 +1,7 @@
-import { ERC1404 } from '../../../typechain';
 import { describeBehaviorOfERC20 } from '../ERC20';
 import { describeBehaviorOfERC1404Base } from './ERC1404Base.behavior';
 import { describeFilter } from '@solidstate/library';
+import { ERC1404 } from '@solidstate/typechain-types';
 import { BigNumber, BigNumberish, ContractTransaction } from 'ethers';
 
 interface ERC1404BehaviorArgs {

--- a/spec/token/ERC1404/ERC1404Base.behavior.ts
+++ b/spec/token/ERC1404/ERC1404Base.behavior.ts
@@ -1,6 +1,6 @@
-import { ERC1404Base } from '../../../typechain';
 import { describeBehaviorOfERC20Base } from '../ERC20';
 import { describeFilter } from '@solidstate/library';
+import { ERC1404Base } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { BigNumber, ContractTransaction } from 'ethers';
 import { ethers } from 'hardhat';

--- a/spec/token/ERC20/ERC20.behavior.ts
+++ b/spec/token/ERC20/ERC20.behavior.ts
@@ -1,8 +1,8 @@
-import { ERC20 } from '../../../typechain';
 import { describeBehaviorOfERC20Base } from './ERC20Base.behavior';
 import { describeBehaviorOfERC20Extended } from './ERC20Extended.behavior';
 import { describeBehaviorOfERC20Metadata } from './ERC20Metadata.behavior';
 import { describeFilter } from '@solidstate/library';
+import { ERC20 } from '@solidstate/typechain-types';
 import { BigNumber, BigNumberish, ContractTransaction } from 'ethers';
 
 interface ERC20BehaviorArgs {

--- a/spec/token/ERC20/ERC20Base.behavior.ts
+++ b/spec/token/ERC20/ERC20Base.behavior.ts
@@ -1,6 +1,6 @@
-import { ERC20Base } from '../../../typechain';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeFilter } from '@solidstate/library';
+import { ERC20Base } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { BigNumber, ContractTransaction } from 'ethers';
 import { ethers } from 'hardhat';

--- a/spec/token/ERC20/ERC20Extended.behavior.ts
+++ b/spec/token/ERC20/ERC20Extended.behavior.ts
@@ -1,7 +1,7 @@
-import { ERC20Extended } from '../../../typechain';
 import { describeBehaviorOfERC20Base } from './ERC20Base.behavior';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeFilter } from '@solidstate/library';
+import { ERC20Extended } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { BigNumber, ContractTransaction } from 'ethers';
 import { ethers } from 'hardhat';

--- a/spec/token/ERC20/ERC20ImplicitApproval.behavior.ts
+++ b/spec/token/ERC20/ERC20ImplicitApproval.behavior.ts
@@ -1,7 +1,7 @@
-import { ERC20ImplicitApproval } from '../../../typechain';
 import { describeBehaviorOfERC20Base } from './ERC20Base.behavior';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeFilter } from '@solidstate/library';
+import { ERC20ImplicitApproval } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { BigNumber, ContractTransaction } from 'ethers';
 import { ethers } from 'hardhat';

--- a/spec/token/ERC20/ERC20Metadata.behavior.ts
+++ b/spec/token/ERC20/ERC20Metadata.behavior.ts
@@ -1,5 +1,5 @@
-import { ERC20Metadata } from '../../../typechain';
 import { describeFilter } from '@solidstate/library';
+import { ERC20Metadata } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { BigNumberish } from 'ethers';
 

--- a/spec/token/ERC20/ERC20Permit.behavior.ts
+++ b/spec/token/ERC20/ERC20Permit.behavior.ts
@@ -1,8 +1,8 @@
-import { ERC20Permit } from '../../../typechain';
 import { describeBehaviorOfERC20Base } from './ERC20Base.behavior';
 import { describeBehaviorOfERC20Metadata } from './ERC20Metadata.behavior';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeFilter, signERC2612Permit } from '@solidstate/library';
+import { ERC20Permit } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { BigNumber, BigNumberish, ContractTransaction } from 'ethers';
 import { ethers } from 'hardhat';

--- a/spec/token/ERC4626/ERC4626.behavior.ts
+++ b/spec/token/ERC4626/ERC4626.behavior.ts
@@ -1,7 +1,7 @@
-import { IERC20, ERC4626 } from '../../../typechain';
 import { describeBehaviorOfERC20 } from '../ERC20';
 import { describeBehaviorOfERC4626Base } from './ERC4626Base.behavior';
 import { describeFilter } from '@solidstate/library';
+import { IERC20, ERC4626 } from '@solidstate/typechain-types';
 import { BigNumber, BigNumberish, ContractTransaction } from 'ethers';
 
 interface ERC4626BehaviorArgs {

--- a/spec/token/ERC4626/ERC4626Base.behavior.ts
+++ b/spec/token/ERC4626/ERC4626Base.behavior.ts
@@ -1,7 +1,7 @@
-import { IERC20, ERC4626Base } from '../../../typechain';
 import { describeBehaviorOfERC20Base } from '../ERC20';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeFilter } from '@solidstate/library';
+import { IERC20, ERC4626Base } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { BigNumber, ContractTransaction } from 'ethers';
 import { ethers } from 'hardhat';

--- a/spec/token/ERC721/ERC721.behavior.ts
+++ b/spec/token/ERC721/ERC721.behavior.ts
@@ -1,9 +1,9 @@
-import { ERC721 } from '../../../typechain';
 import { describeBehaviorOfERC721Base } from './ERC721Base.behavior';
 import { describeBehaviorOfERC721Enumerable } from './ERC721Enumerable.behavior';
 import { describeBehaviorOfERC721Metadata } from './ERC721Metadata.behavior';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeFilter } from '@solidstate/library';
+import { ERC721 } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { BigNumber, ContractTransaction } from 'ethers';
 import { ethers } from 'hardhat';

--- a/spec/token/ERC721/ERC721Base.behavior.ts
+++ b/spec/token/ERC721/ERC721Base.behavior.ts
@@ -1,7 +1,7 @@
-import { ERC721Base } from '../../../typechain';
 import { describeBehaviorOfERC165 } from '../../introspection';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeFilter } from '@solidstate/library';
+import { ERC721Base } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { deployMockContract } from 'ethereum-waffle';
 import { BigNumber, ContractTransaction } from 'ethers';

--- a/spec/token/ERC721/ERC721Enumerable.behavior.ts
+++ b/spec/token/ERC721/ERC721Enumerable.behavior.ts
@@ -1,6 +1,6 @@
-import { ERC721Enumerable } from '../../../typechain';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeFilter } from '@solidstate/library';
+import { ERC721Enumerable } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { BigNumber, ContractTransaction } from 'ethers';
 import { ethers } from 'hardhat';

--- a/spec/token/ERC721/ERC721Metadata.behavior.ts
+++ b/spec/token/ERC721/ERC721Metadata.behavior.ts
@@ -1,5 +1,5 @@
-import { ERC721Metadata } from '../../../typechain';
 import { describeFilter } from '@solidstate/library';
+import { ERC721Metadata } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 
 interface ERC721MetadataBehaviorArgs {

--- a/test/access/Ownable.ts
+++ b/test/access/Ownable.ts
@@ -1,6 +1,6 @@
-import { OwnableMock, OwnableMock__factory } from '../../typechain';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeBehaviorOfOwnable } from '@solidstate/spec';
+import { OwnableMock, OwnableMock__factory } from '@solidstate/typechain-types';
 import { ethers } from 'hardhat';
 
 describe('Ownable', function () {

--- a/test/access/SafeOwnable.ts
+++ b/test/access/SafeOwnable.ts
@@ -1,6 +1,9 @@
-import { SafeOwnableMock, SafeOwnableMock__factory } from '../../typechain';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeBehaviorOfSafeOwnable } from '@solidstate/spec';
+import {
+  SafeOwnableMock,
+  SafeOwnableMock__factory,
+} from '@solidstate/typechain-types';
 import { ethers } from 'hardhat';
 
 describe('SafeOwnable', function () {

--- a/test/cryptography/ECDSA.ts
+++ b/test/cryptography/ECDSA.ts
@@ -1,5 +1,5 @@
-import { ECDSAMock, ECDSAMock__factory } from '../../typechain';
 import { hashData, signData } from '@solidstate/library';
+import { ECDSAMock, ECDSAMock__factory } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 

--- a/test/cryptography/MerkleProof.ts
+++ b/test/cryptography/MerkleProof.ts
@@ -1,4 +1,7 @@
-import { MerkleProofMock, MerkleProofMock__factory } from '../../typechain';
+import {
+  MerkleProofMock,
+  MerkleProofMock__factory,
+} from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import keccak256 from 'keccak256';

--- a/test/factory/CloneFactory.ts
+++ b/test/factory/CloneFactory.ts
@@ -1,5 +1,8 @@
-import { CloneFactoryMock, CloneFactoryMock__factory } from '../../typechain';
 import { describeBehaviorOfCloneFactory } from '@solidstate/spec';
+import {
+  CloneFactoryMock,
+  CloneFactoryMock__factory,
+} from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 

--- a/test/factory/Factory.ts
+++ b/test/factory/Factory.ts
@@ -1,5 +1,5 @@
-import { FactoryMock, FactoryMock__factory } from '../../typechain';
 import { describeBehaviorOfFactory } from '@solidstate/spec';
+import { FactoryMock, FactoryMock__factory } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 

--- a/test/factory/MetamorphicFactory.ts
+++ b/test/factory/MetamorphicFactory.ts
@@ -1,8 +1,8 @@
+import { describeBehaviorOfMetamorphicFactory } from '@solidstate/spec';
 import {
   MetamorphicFactoryMock,
   MetamorphicFactoryMock__factory,
-} from '../../typechain';
-import { describeBehaviorOfMetamorphicFactory } from '@solidstate/spec';
+} from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 

--- a/test/factory/MinimalProxyFactory.ts
+++ b/test/factory/MinimalProxyFactory.ts
@@ -1,8 +1,8 @@
+import { describeBehaviorOfMinimalProxyFactory } from '@solidstate/spec';
 import {
   MinimalProxyFactoryMock,
   MinimalProxyFactoryMock__factory,
-} from '../../typechain';
-import { describeBehaviorOfMinimalProxyFactory } from '@solidstate/spec';
+} from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 

--- a/test/introspection/ERC165.ts
+++ b/test/introspection/ERC165.ts
@@ -1,5 +1,5 @@
-import { ERC165Mock, ERC165Mock__factory } from '../../typechain';
 import { describeBehaviorOfERC165 } from '@solidstate/spec';
+import { ERC165Mock, ERC165Mock__factory } from '@solidstate/typechain-types';
 import { ethers } from 'hardhat';
 
 describe('ERC165', function () {

--- a/test/multisig/ECDSAMultisigWallet.ts
+++ b/test/multisig/ECDSAMultisigWallet.ts
@@ -1,9 +1,9 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { describeBehaviorOfECDSAMultisigWallet } from '@solidstate/spec';
 import {
   ECDSAMultisigWalletMock,
   ECDSAMultisigWalletMock__factory,
-} from '../../typechain';
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
-import { describeBehaviorOfECDSAMultisigWallet } from '@solidstate/spec';
+} from '@solidstate/typechain-types';
 import { ethers } from 'hardhat';
 
 describe('ECDSAMultisigWallet', function () {

--- a/test/proxy/Proxy.ts
+++ b/test/proxy/Proxy.ts
@@ -1,11 +1,11 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { describeBehaviorOfProxy } from '@solidstate/spec';
 import {
   Ownable,
   OwnableMock__factory,
   ProxyMock,
   ProxyMock__factory,
-} from '../../typechain';
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
-import { describeBehaviorOfProxy } from '@solidstate/spec';
+} from '@solidstate/typechain-types';
 import { ethers } from 'hardhat';
 
 describe('Proxy', function () {

--- a/test/proxy/diamond/Diamond.ts
+++ b/test/proxy/diamond/Diamond.ts
@@ -1,6 +1,6 @@
-import { Diamond, DiamondMock__factory } from '../../../typechain';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeBehaviorOfDiamond } from '@solidstate/spec';
+import { Diamond, DiamondMock__factory } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 

--- a/test/proxy/diamond/DiamondBase.ts
+++ b/test/proxy/diamond/DiamondBase.ts
@@ -1,9 +1,9 @@
+import { describeBehaviorOfDiamondBase } from '@solidstate/spec';
 import {
   DiamondBaseMock,
   DiamondBaseMock__factory,
   OwnableMock__factory,
-} from '../../../typechain';
-import { describeBehaviorOfDiamondBase } from '@solidstate/spec';
+} from '@solidstate/typechain-types';
 import { ethers } from 'hardhat';
 
 describe('DiamondBase', function () {

--- a/test/proxy/diamond/DiamondCuttable.ts
+++ b/test/proxy/diamond/DiamondCuttable.ts
@@ -1,9 +1,9 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { describeBehaviorOfDiamondCuttable } from '@solidstate/spec';
 import {
   DiamondCuttableMock,
   DiamondCuttableMock__factory,
-} from '../../../typechain';
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
-import { describeBehaviorOfDiamondCuttable } from '@solidstate/spec';
+} from '@solidstate/typechain-types';
 import { ethers } from 'hardhat';
 
 describe('DiamondCuttable', function () {

--- a/test/proxy/diamond/DiamondLoupe.ts
+++ b/test/proxy/diamond/DiamondLoupe.ts
@@ -1,8 +1,8 @@
+import { describeBehaviorOfDiamondLoupe } from '@solidstate/spec';
 import {
   DiamondLoupeMock,
   DiamondLoupeMock__factory,
-} from '../../../typechain';
-import { describeBehaviorOfDiamondLoupe } from '@solidstate/spec';
+} from '@solidstate/typechain-types';
 import { deployMockContract } from 'ethereum-waffle';
 import { ethers } from 'hardhat';
 

--- a/test/proxy/managed/ManagedProxy.ts
+++ b/test/proxy/managed/ManagedProxy.ts
@@ -1,8 +1,8 @@
+import { describeBehaviorOfManagedProxy } from '@solidstate/spec';
 import {
   ManagedProxyMock,
   ManagedProxyMock__factory,
-} from '../../../typechain';
-import { describeBehaviorOfManagedProxy } from '@solidstate/spec';
+} from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { deployMockContract } from 'ethereum-waffle';
 import { ethers } from 'hardhat';

--- a/test/proxy/managed/ManagedProxyOwnable.ts
+++ b/test/proxy/managed/ManagedProxyOwnable.ts
@@ -1,9 +1,9 @@
+import { describeBehaviorOfManagedProxyOwnable } from '@solidstate/spec';
 import {
   ManagedProxyOwnableMock,
   ManagedProxyOwnableMock__factory,
   OwnableMock__factory,
-} from '../../../typechain';
-import { describeBehaviorOfManagedProxyOwnable } from '@solidstate/spec';
+} from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { deployMockContract } from 'ethereum-waffle';
 import { ethers } from 'hardhat';

--- a/test/proxy/upgradeable/UpgradeableProxy.ts
+++ b/test/proxy/upgradeable/UpgradeableProxy.ts
@@ -1,8 +1,8 @@
+import { describeBehaviorOfUpgradeableProxy } from '@solidstate/spec';
 import {
   UpgradeableProxyMock,
   UpgradeableProxyMock__factory,
-} from '../../../typechain';
-import { describeBehaviorOfUpgradeableProxy } from '@solidstate/spec';
+} from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { deployMockContract } from 'ethereum-waffle';
 import { ethers } from 'hardhat';

--- a/test/proxy/upgradeable/UpgradeableProxyOwnable.ts
+++ b/test/proxy/upgradeable/UpgradeableProxyOwnable.ts
@@ -1,9 +1,9 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { describeBehaviorOfUpgradeableProxyOwnable } from '@solidstate/spec';
 import {
   UpgradeableProxyOwnableMock,
   UpgradeableProxyOwnableMock__factory,
-} from '../../../typechain';
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
-import { describeBehaviorOfUpgradeableProxyOwnable } from '@solidstate/spec';
+} from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { deployMockContract } from 'ethereum-waffle';
 import { ethers } from 'hardhat';

--- a/test/signature/ERC1271Ownable.ts
+++ b/test/signature/ERC1271Ownable.ts
@@ -1,9 +1,9 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { describeBehaviorOfERC1271Ownable } from '@solidstate/spec';
 import {
   ERC1271OwnableMock,
   ERC1271OwnableMock__factory,
-} from '../../typechain';
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
-import { describeBehaviorOfERC1271Ownable } from '@solidstate/spec';
+} from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 

--- a/test/signature/ERC1271Stored.ts
+++ b/test/signature/ERC1271Stored.ts
@@ -1,5 +1,8 @@
-import { ERC1271StoredMock, ERC1271StoredMock__factory } from '../../typechain';
 import { describeBehaviorOfERC1271Stored } from '@solidstate/spec';
+import {
+  ERC1271StoredMock,
+  ERC1271StoredMock__factory,
+} from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 

--- a/test/token/ERC1155/ERC1155.ts
+++ b/test/token/ERC1155/ERC1155.ts
@@ -1,5 +1,5 @@
-import { ERC1155Mock, ERC1155Mock__factory } from '../../../typechain';
 import { describeBehaviorOfERC1155 } from '@solidstate/spec';
+import { ERC1155Mock, ERC1155Mock__factory } from '@solidstate/typechain-types';
 import { ethers } from 'hardhat';
 
 describe('ERC1155', function () {

--- a/test/token/ERC1155/ERC1155Base.ts
+++ b/test/token/ERC1155/ERC1155Base.ts
@@ -1,6 +1,9 @@
-import { ERC1155BaseMock, ERC1155BaseMock__factory } from '../../../typechain';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeBehaviorOfERC1155Base } from '@solidstate/spec';
+import {
+  ERC1155BaseMock,
+  ERC1155BaseMock__factory,
+} from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 

--- a/test/token/ERC1155/ERC1155Enumerable.ts
+++ b/test/token/ERC1155/ERC1155Enumerable.ts
@@ -1,8 +1,8 @@
+import { describeBehaviorOfERC1155Enumerable } from '@solidstate/spec';
 import {
   ERC1155EnumerableMock,
   ERC1155EnumerableMock__factory,
-} from '../../../typechain';
-import { describeBehaviorOfERC1155Enumerable } from '@solidstate/spec';
+} from '@solidstate/typechain-types';
 import { ethers } from 'hardhat';
 
 describe('ERC1155Enumerable', function () {

--- a/test/token/ERC1155/ERC1155Metadata.ts
+++ b/test/token/ERC1155/ERC1155Metadata.ts
@@ -1,8 +1,8 @@
+import { describeBehaviorOfERC1155Metadata } from '@solidstate/spec';
 import {
   ERC1155MetadataMock,
   ERC1155MetadataMock__factory,
-} from '../../../typechain';
-import { describeBehaviorOfERC1155Metadata } from '@solidstate/spec';
+} from '@solidstate/typechain-types';
 import { ethers } from 'hardhat';
 
 describe('ERC1155Metadata', function () {

--- a/test/token/ERC1404/ERC1404.ts
+++ b/test/token/ERC1404/ERC1404.ts
@@ -1,5 +1,5 @@
-import { ERC1404Mock, ERC1404Mock__factory } from '../../../typechain';
 import { describeBehaviorOfERC1404 } from '@solidstate/spec';
+import { ERC1404Mock, ERC1404Mock__factory } from '@solidstate/typechain-types';
 import { ethers } from 'hardhat';
 
 let restrictions = [

--- a/test/token/ERC1404/ERC1404Base.ts
+++ b/test/token/ERC1404/ERC1404Base.ts
@@ -1,5 +1,8 @@
-import { ERC1404BaseMock, ERC1404BaseMock__factory } from '../../../typechain';
 import { describeBehaviorOfERC1404Base } from '@solidstate/spec';
+import {
+  ERC1404BaseMock,
+  ERC1404BaseMock__factory,
+} from '@solidstate/typechain-types';
 import { BigNumber } from 'ethers';
 import { ethers } from 'hardhat';
 

--- a/test/token/ERC20/ERC20.ts
+++ b/test/token/ERC20/ERC20.ts
@@ -1,5 +1,5 @@
-import { ERC20Mock, ERC20Mock__factory } from '../../../typechain';
 import { describeBehaviorOfERC20 } from '@solidstate/spec';
+import { ERC20Mock, ERC20Mock__factory } from '@solidstate/typechain-types';
 import { ethers } from 'hardhat';
 
 const name = 'ERC20Metadata.name';

--- a/test/token/ERC20/ERC20Base.ts
+++ b/test/token/ERC20/ERC20Base.ts
@@ -1,10 +1,10 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { describeBehaviorOfERC20Base } from '@solidstate/spec';
 import {
   ERC20Base,
   ERC20BaseMock,
   ERC20BaseMock__factory,
-} from '../../../typechain';
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
-import { describeBehaviorOfERC20Base } from '@solidstate/spec';
+} from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 

--- a/test/token/ERC20/ERC20Extended.ts
+++ b/test/token/ERC20/ERC20Extended.ts
@@ -1,8 +1,8 @@
+import { describeBehaviorOfERC20Extended } from '@solidstate/spec';
 import {
   ERC20ExtendedMock,
   ERC20ExtendedMock__factory,
-} from '../../../typechain';
-import { describeBehaviorOfERC20Extended } from '@solidstate/spec';
+} from '@solidstate/typechain-types';
 import { ethers } from 'hardhat';
 
 describe('ERC20Extended', function () {

--- a/test/token/ERC20/ERC20ImplicitApproval.ts
+++ b/test/token/ERC20/ERC20ImplicitApproval.ts
@@ -1,9 +1,9 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { describeBehaviorOfERC20ImplicitApproval } from '@solidstate/spec';
 import {
   ERC20ImplicitApprovalMock,
   ERC20ImplicitApprovalMock__factory,
-} from '../../../typechain';
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
-import { describeBehaviorOfERC20ImplicitApproval } from '@solidstate/spec';
+} from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 

--- a/test/token/ERC20/ERC20Metadata.ts
+++ b/test/token/ERC20/ERC20Metadata.ts
@@ -1,8 +1,8 @@
+import { describeBehaviorOfERC20Metadata } from '@solidstate/spec';
 import {
   ERC20MetadataMock,
   ERC20MetadataMock__factory,
-} from '../../../typechain';
-import { describeBehaviorOfERC20Metadata } from '@solidstate/spec';
+} from '@solidstate/typechain-types';
 import { ethers } from 'hardhat';
 
 describe('ERC20Metadata', function () {

--- a/test/token/ERC20/ERC20Permit.ts
+++ b/test/token/ERC20/ERC20Permit.ts
@@ -1,6 +1,9 @@
-import { ERC20PermitMock, ERC20PermitMock__factory } from '../../../typechain';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeBehaviorOfERC20Permit } from '@solidstate/spec';
+import {
+  ERC20PermitMock,
+  ERC20PermitMock__factory,
+} from '@solidstate/typechain-types';
 import { ethers } from 'hardhat';
 
 describe('ERC20Permit', function () {

--- a/test/token/ERC4626/ERC4626.ts
+++ b/test/token/ERC4626/ERC4626.ts
@@ -1,10 +1,10 @@
+import { describeBehaviorOfERC4626 } from '@solidstate/spec';
 import {
   ERC20Mock,
   ERC20Mock__factory,
   ERC4626Mock,
   ERC4626Mock__factory,
-} from '../../../typechain';
-import { describeBehaviorOfERC4626 } from '@solidstate/spec';
+} from '@solidstate/typechain-types';
 import { BigNumber } from 'ethers';
 import { ethers } from 'hardhat';
 

--- a/test/token/ERC4626/ERC4626Base.ts
+++ b/test/token/ERC4626/ERC4626Base.ts
@@ -1,14 +1,14 @@
-import {
-  ERC20Mock,
-  ERC20Mock__factory,
-  ERC4626BaseMock,
-  ERC4626BaseMock__factory,
-} from '../../../typechain';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import {
   describeBehaviorOfCloneFactory,
   describeBehaviorOfERC4626Base,
 } from '@solidstate/spec';
+import {
+  ERC20Mock,
+  ERC20Mock__factory,
+  ERC4626BaseMock,
+  ERC4626BaseMock__factory,
+} from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { BigNumber } from 'ethers';
 import { ethers } from 'hardhat';

--- a/test/token/ERC721/ERC721.ts
+++ b/test/token/ERC721/ERC721.ts
@@ -1,5 +1,5 @@
-import { ERC721Mock, ERC721Mock__factory } from '../../../typechain';
 import { describeBehaviorOfERC721 } from '@solidstate/spec';
+import { ERC721Mock, ERC721Mock__factory } from '@solidstate/typechain-types';
 import { ethers } from 'hardhat';
 
 const name = 'ERC721Metadata.name';

--- a/test/token/ERC721/ERC721Base.ts
+++ b/test/token/ERC721/ERC721Base.ts
@@ -1,10 +1,10 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { describeBehaviorOfERC721Base } from '@solidstate/spec';
 import {
   ERC721Base,
   ERC721BaseMock,
   ERC721BaseMock__factory,
-} from '../../../typechain';
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
-import { describeBehaviorOfERC721Base } from '@solidstate/spec';
+} from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { deployMockContract } from 'ethereum-waffle';
 import { ethers } from 'hardhat';

--- a/test/token/ERC721/ERC721Enumerable.ts
+++ b/test/token/ERC721/ERC721Enumerable.ts
@@ -1,8 +1,8 @@
+import { describeBehaviorOfERC721Enumerable } from '@solidstate/spec';
 import {
   ERC721EnumerableMock,
   ERC721EnumerableMock__factory,
-} from '../../../typechain';
-import { describeBehaviorOfERC721Enumerable } from '@solidstate/spec';
+} from '@solidstate/typechain-types';
 import { ethers } from 'hardhat';
 
 describe('ERC721Enumerable', function () {

--- a/test/token/ERC721/ERC721Metadata.ts
+++ b/test/token/ERC721/ERC721Metadata.ts
@@ -1,8 +1,8 @@
+import { describeBehaviorOfERC721Metadata } from '@solidstate/spec';
 import {
   ERC721MetadataMock,
   ERC721MetadataMock__factory,
-} from '../../../typechain';
-import { describeBehaviorOfERC721Metadata } from '@solidstate/spec';
+} from '@solidstate/typechain-types';
 import { ethers } from 'hardhat';
 
 describe('ERC721Metadata', function () {

--- a/test/utils/AddressUtils.ts
+++ b/test/utils/AddressUtils.ts
@@ -1,5 +1,8 @@
-import { AddressUtilsMock, AddressUtilsMock__factory } from '../../typechain';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import {
+  AddressUtilsMock,
+  AddressUtilsMock__factory,
+} from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { deployMockContract } from 'ethereum-waffle';
 import { BytesLike, BigNumber } from 'ethers';

--- a/test/utils/ArrayUtils.ts
+++ b/test/utils/ArrayUtils.ts
@@ -1,5 +1,8 @@
-import { ArrayUtilsMock, ArrayUtilsMock__factory } from '../../typechain';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import {
+  ArrayUtilsMock,
+  ArrayUtilsMock__factory,
+} from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { BigNumber } from 'ethers';
 import { ethers } from 'hardhat';

--- a/test/utils/Math.ts
+++ b/test/utils/Math.ts
@@ -1,4 +1,4 @@
-import { MathMock, MathMock__factory } from '../../typechain';
+import { MathMock, MathMock__factory } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 

--- a/test/utils/Multicall.ts
+++ b/test/utils/Multicall.ts
@@ -1,4 +1,7 @@
-import { MulticallMock, MulticallMock__factory } from '../../typechain';
+import {
+  MulticallMock,
+  MulticallMock__factory,
+} from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { BytesLike } from 'ethers';
 import { ethers } from 'hardhat';

--- a/test/utils/ReentrancyGuard.ts
+++ b/test/utils/ReentrancyGuard.ts
@@ -1,8 +1,8 @@
+import { describeBehaviorOfReentrancyGuard } from '@solidstate/spec';
 import {
   ReentrancyGuardMock,
   ReentrancyGuardMock__factory,
-} from '../../typechain';
-import { describeBehaviorOfReentrancyGuard } from '@solidstate/spec';
+} from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 

--- a/test/utils/UintUtils.ts
+++ b/test/utils/UintUtils.ts
@@ -1,4 +1,7 @@
-import { UintUtilsMock, UintUtilsMock__factory } from '../../typechain';
+import {
+  UintUtilsMock,
+  UintUtilsMock__factory,
+} from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 


### PR DESCRIPTION
This removes the need for each test file's awareness of its location relative to files it depends on.
Example:
`'../../../typechain'` => `'@solidstate/typechain-types'`

@NouDaimon Try this:
1. clone fresh repository
2. switch to this branch
3. `yarn install`
4. run the tests

Let me know if you have any issues with that process.