### PR TITLE
Include `ERC20Metadata` in ERC4626 contracts

### DIFF
--- a/abi/ERC4626Base.json
+++ b/abi/ERC4626Base.json
@@ -236,6 +236,19 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -360,6 +373,19 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -462,6 +488,19 @@
       }
     ],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/abi/IERC4626.json
+++ b/abi/IERC4626.json
@@ -236,6 +236,19 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -360,6 +373,19 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -462,6 +488,19 @@
       }
     ],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/abi/IERC4626Base.json
+++ b/abi/IERC4626Base.json
@@ -236,6 +236,19 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -360,6 +373,19 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -462,6 +488,19 @@
       }
     ],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/contracts/token/ERC4626/IERC4626.sol
+++ b/contracts/token/ERC4626/IERC4626.sol
@@ -3,13 +3,14 @@
 pragma solidity ^0.8.8;
 
 import { IERC20 } from '../ERC20/IERC20.sol';
+import { IERC20Metadata } from '../ERC20/metadata/IERC20Metadata.sol';
 import { IERC4626Internal } from './IERC4626Internal.sol';
 
 /**
  * @title ERC4626 interface
  * @dev see https://github.com/ethereum/EIPs/issues/4626
  */
-interface IERC4626 is IERC4626Internal, IERC20 {
+interface IERC4626 is IERC4626Internal, IERC20, IERC20Metadata {
     /**
      * @notice get the address of the base token used for vault accountin purposes
      * @return base token address

--- a/contracts/token/ERC4626/SolidStateERC4626Mock.sol
+++ b/contracts/token/ERC4626/SolidStateERC4626Mock.sol
@@ -2,6 +2,7 @@
 
 pragma solidity ^0.8.8;
 
+import { ERC20MetadataStorage } from '../ERC20/metadata/ERC20MetadataStorage.sol';
 import { SolidStateERC4626 } from './SolidStateERC4626.sol';
 import { ERC4626BaseStorage } from './base/ERC4626BaseStorage.sol';
 
@@ -19,11 +20,18 @@ contract SolidStateERC4626Mock is SolidStateERC4626 {
         uint256 shareAmount
     );
 
-    constructor(address asset) {
-        ERC4626BaseStorage.Layout storage ERC4626Layout = ERC4626BaseStorage
-            .layout();
+    constructor(
+        address asset,
+        string memory name,
+        string memory symbol,
+        uint8 decimals
+    ) {
+        ERC4626BaseStorage.layout().asset = asset;
 
-        ERC4626Layout.asset = asset;
+        ERC20MetadataStorage.Layout storage l = ERC20MetadataStorage.layout();
+        l.name = name;
+        l.symbol = symbol;
+        l.decimals = decimals;
     }
 
     function _totalAssets() internal view override returns (uint256) {

--- a/contracts/token/ERC4626/base/ERC4626Base.sol
+++ b/contracts/token/ERC4626/base/ERC4626Base.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.8;
 
 import { ERC20Base } from '../../ERC20/base/ERC20Base.sol';
+import { ERC20Metadata } from '../../ERC20/metadata/ERC20Metadata.sol';
 import { IERC4626 } from '../IERC4626.sol';
 import { IERC4626Base } from './IERC4626Base.sol';
 import { ERC4626BaseInternal } from './ERC4626BaseInternal.sol';
@@ -10,7 +11,12 @@ import { ERC4626BaseInternal } from './ERC4626BaseInternal.sol';
 /**
  * @title Base ERC4626 implementation
  */
-abstract contract ERC4626Base is IERC4626Base, ERC4626BaseInternal, ERC20Base {
+abstract contract ERC4626Base is
+    IERC4626Base,
+    ERC4626BaseInternal,
+    ERC20Base,
+    ERC20Metadata
+{
     /**
      * @inheritdoc IERC4626
      */

--- a/contracts/token/ERC4626/base/ERC4626BaseInternal.sol
+++ b/contracts/token/ERC4626/base/ERC4626BaseInternal.sol
@@ -5,13 +5,18 @@ pragma solidity ^0.8.8;
 import { SafeERC20 } from '../../../utils/SafeERC20.sol';
 import { IERC20 } from '../../ERC20/IERC20.sol';
 import { ERC20BaseInternal } from '../../ERC20/base/ERC20BaseInternal.sol';
+import { ERC20MetadataInternal } from '../../ERC20/metadata/ERC20MetadataInternal.sol';
 import { IERC4626Internal } from '../IERC4626Internal.sol';
 import { ERC4626BaseStorage } from './ERC4626BaseStorage.sol';
 
 /**
  * @title Base ERC4626 internal functions
  */
-abstract contract ERC4626BaseInternal is IERC4626Internal, ERC20BaseInternal {
+abstract contract ERC4626BaseInternal is
+    IERC4626Internal,
+    ERC20BaseInternal,
+    ERC20MetadataInternal
+{
     using SafeERC20 for IERC20;
 
     /**

--- a/contracts/token/ERC4626/base/ERC4626BaseMock.sol
+++ b/contracts/token/ERC4626/base/ERC4626BaseMock.sol
@@ -2,6 +2,7 @@
 
 pragma solidity ^0.8.8;
 
+import { ERC20MetadataStorage } from '../../ERC20/metadata/ERC20MetadataStorage.sol';
 import { ERC4626Base } from './ERC4626Base.sol';
 import { ERC4626BaseStorage } from './ERC4626BaseStorage.sol';
 
@@ -19,11 +20,18 @@ contract ERC4626BaseMock is ERC4626Base {
         uint256 shareAmount
     );
 
-    constructor(address asset) {
-        ERC4626BaseStorage.Layout storage ERC4626Layout = ERC4626BaseStorage
-            .layout();
+    constructor(
+        address asset,
+        string memory name,
+        string memory symbol,
+        uint8 decimals
+    ) {
+        ERC4626BaseStorage.layout().asset = asset;
 
-        ERC4626Layout.asset = asset;
+        ERC20MetadataStorage.Layout storage l = ERC20MetadataStorage.layout();
+        l.name = name;
+        l.symbol = symbol;
+        l.decimals = decimals;
     }
 
     function _totalAssets() internal view override returns (uint256) {

--- a/spec/token/ERC4626/SolidStateERC4626.behavior.ts
+++ b/spec/token/ERC4626/SolidStateERC4626.behavior.ts
@@ -25,6 +25,7 @@ export function describeBehaviorOfSolidStateERC4626(
 
     describeBehaviorOfERC4626Base(deploy, args, [
       '::ERC20Base',
+      '::ERC20Metadata',
       ...(skips ?? []),
     ]);
   });

--- a/spec/token/ERC4626/SolidStateERC4626.behavior.ts
+++ b/spec/token/ERC4626/SolidStateERC4626.behavior.ts
@@ -7,8 +7,7 @@ import {
   ERC4626BaseBehaviorArgs,
 } from './ERC4626Base.behavior';
 import { describeFilter } from '@solidstate/library';
-import { IERC20, ISolidStateERC4626 } from '@solidstate/typechain-types';
-import { BigNumber, BigNumberish, ContractTransaction } from 'ethers';
+import { ISolidStateERC4626 } from '@solidstate/typechain-types';
 
 export interface SolidStateERC4626BehaviorArgs
   extends SolidStateERC20BehaviorArgs,
@@ -16,46 +15,17 @@ export interface SolidStateERC4626BehaviorArgs
 
 export function describeBehaviorOfSolidStateERC4626(
   deploy: () => Promise<ISolidStateERC4626>,
-  {
-    getAsset,
-    mint,
-    burn,
-    allowance,
-    mintAsset,
-    name,
-    symbol,
-    decimals,
-    supply,
-  }: SolidStateERC4626BehaviorArgs,
+  args: SolidStateERC4626BehaviorArgs,
   skips?: string[],
 ) {
   const describe = describeFilter(skips);
 
   describe('::SolidStateERC4626', function () {
-    describeBehaviorOfSolidStateERC20(
-      deploy,
-      {
-        mint,
-        burn,
-        allowance,
-        name,
-        symbol,
-        decimals,
-        supply,
-      },
-      skips,
-    );
+    describeBehaviorOfSolidStateERC20(deploy, args, skips);
 
-    describeBehaviorOfERC4626Base(
-      deploy,
-      {
-        getAsset,
-        mint,
-        burn,
-        mintAsset,
-        supply,
-      },
-      ['::ERC20Base', ...(skips ?? [])],
-    );
+    describeBehaviorOfERC4626Base(deploy, args, [
+      '::ERC20Base',
+      ...(skips ?? []),
+    ]);
   });
 }

--- a/test/token/ERC4626/ERC4626Base.ts
+++ b/test/token/ERC4626/ERC4626Base.ts
@@ -29,14 +29,17 @@ describe('ERC4626Base', () => {
 
   beforeEach(async () => {
     assetInstance = await new SolidStateERC20Mock__factory(deployer).deploy(
-      name,
-      symbol,
-      decimals,
+      '',
+      '',
+      0,
       ethers.constants.Zero,
     );
 
     instance = await new ERC4626BaseMock__factory(deployer).deploy(
       assetInstance.address,
+      name,
+      symbol,
+      decimals,
     );
   });
 

--- a/test/token/ERC4626/ERC4626Base.ts
+++ b/test/token/ERC4626/ERC4626Base.ts
@@ -13,6 +13,10 @@ import { expect } from 'chai';
 import { BigNumber } from 'ethers';
 import { ethers } from 'hardhat';
 
+const name = 'ERC20Metadata.name';
+const symbol = 'ERC20Metadata.symbol';
+const decimals = 18;
+
 describe('ERC4626Base', () => {
   let deployer: SignerWithAddress;
   let depositor: SignerWithAddress;
@@ -25,9 +29,9 @@ describe('ERC4626Base', () => {
 
   beforeEach(async () => {
     assetInstance = await new SolidStateERC20Mock__factory(deployer).deploy(
-      '',
-      '',
-      0,
+      name,
+      symbol,
+      decimals,
       ethers.constants.Zero,
     );
 
@@ -45,6 +49,9 @@ describe('ERC4626Base', () => {
       instance.__burn(recipient, amount),
     mintAsset: (recipient: string, amount: BigNumber) =>
       assetInstance.__mint(recipient, amount),
+    name,
+    symbol,
+    decimals,
   });
 
   describe('__internal', () => {

--- a/test/token/ERC4626/SolidStateERC4626.ts
+++ b/test/token/ERC4626/SolidStateERC4626.ts
@@ -8,6 +8,10 @@ import {
 import { BigNumber } from 'ethers';
 import { ethers } from 'hardhat';
 
+const name = 'ERC20Metadata.name';
+const symbol = 'ERC20Metadata.symbol';
+const decimals = 18;
+
 describe('SolidStateERC4626', function () {
   let assetInstance: SolidStateERC20Mock;
   let instance: SolidStateERC4626Mock;
@@ -16,9 +20,9 @@ describe('SolidStateERC4626', function () {
     const [deployer] = await ethers.getSigners();
 
     assetInstance = await new SolidStateERC20Mock__factory(deployer).deploy(
-      '',
-      '',
-      0,
+      name,
+      symbol,
+      decimals,
       ethers.constants.Zero,
     );
 
@@ -35,9 +39,9 @@ describe('SolidStateERC4626', function () {
       instance.callStatic.allowance(holder, spender),
     mintAsset: (recipient: string, amount: BigNumber) =>
       assetInstance.__mint(recipient, amount),
-    name: '',
-    symbol: '',
-    decimals: 0,
+    name,
+    symbol,
+    decimals,
     supply: ethers.constants.Zero,
   });
 });

--- a/test/token/ERC4626/SolidStateERC4626.ts
+++ b/test/token/ERC4626/SolidStateERC4626.ts
@@ -28,6 +28,9 @@ describe('SolidStateERC4626', function () {
 
     instance = await new SolidStateERC4626Mock__factory(deployer).deploy(
       assetInstance.address,
+      name,
+      symbol,
+      decimals,
     );
   });
 


### PR DESCRIPTION
closes #110 

@0xCourtney A fix to inheritance ordering made in #119 enabled this change.