### PR TITLE
Update and test `EnumerableMap`

### DIFF
--- a/contracts/data/EnumerableMap.sol
+++ b/contracts/data/EnumerableMap.sol
@@ -139,6 +139,44 @@ library EnumerableMap {
         return _remove(map._inner, bytes32(key));
     }
 
+    function toArray(AddressToAddressMap storage map)
+        internal
+        view
+        returns (address[] memory keys, address[] memory values)
+    {
+        uint256 len = map._inner._entries.length;
+        keys = new address[](len);
+        values = new address[](len);
+        unchecked {
+            for (uint256 i; i < len; ++i) {
+                keys[i] = address(
+                    uint160(uint256(map._inner._entries[i]._key))
+                );
+                values[i] = address(
+                    uint160(uint256(map._inner._entries[i]._value))
+                );
+            }
+        }
+    }
+
+    function toArray(UintToAddressMap storage map)
+        internal
+        view
+        returns (uint256[] memory keys, address[] memory values)
+    {
+        uint256 len = map._inner._entries.length;
+        keys = new uint256[](len);
+        values = new address[](len);
+        unchecked {
+            for (uint256 i; i < len; ++i) {
+                keys[i] = uint256(map._inner._entries[i]._key);
+                values[i] = address(
+                    uint160(uint256(map._inner._entries[i]._value))
+                );
+            }
+        }
+    }
+
     function _at(Map storage map, uint256 index)
         private
         view

--- a/contracts/data/EnumerableMap.sol
+++ b/contracts/data/EnumerableMap.sol
@@ -36,18 +36,10 @@ library EnumerableMap {
     {
         (bytes32 key, bytes32 value) = _at(map._inner, index);
 
-        address addressKey;
-        address addressValue;
-
-        assembly {
-            addressKey := and(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF, key)
-            addressValue := and(
-                0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF,
-                value
-            )
-        }
-
-        return (addressKey, addressValue);
+        return (
+            address(uint160(uint256(key))),
+            address(uint160(uint256(value)))
+        );
     }
 
     function at(UintToAddressMap storage map, uint256 index)

--- a/contracts/data/EnumerableMap.sol
+++ b/contracts/data/EnumerableMap.sol
@@ -35,11 +35,19 @@ library EnumerableMap {
         returns (address, address)
     {
         (bytes32 key, bytes32 value) = _at(map._inner, index);
+
         address addressKey;
+        address addressValue;
+
         assembly {
-            addressKey := mload(add(key, 20))
+            addressKey := and(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF, key)
+            addressValue := and(
+                0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF,
+                value
+            )
         }
-        return (addressKey, address(uint160(uint256(value))));
+
+        return (addressKey, addressValue);
     }
 
     function at(UintToAddressMap storage map, uint256 index)

--- a/contracts/data/EnumerableMap.sol
+++ b/contracts/data/EnumerableMap.sol
@@ -177,6 +177,70 @@ library EnumerableMap {
         }
     }
 
+    function keys(AddressToAddressMap storage map)
+        internal
+        view
+        returns (address[] memory keys)
+    {
+        uint256 len = map._inner._entries.length;
+        keys = new address[](len);
+
+        unchecked {
+            for (uint256 i; i < len; ++i) {
+                keys[i] = address(
+                    uint160(uint256(map._inner._entries[i]._key))
+                );
+            }
+        }
+    }
+
+    function keys(UintToAddressMap storage map)
+        internal
+        view
+        returns (uint256[] memory keys)
+    {
+        uint256 len = map._inner._entries.length;
+        keys = new uint256[](len);
+
+        unchecked {
+            for (uint256 i; i < len; ++i) {
+                keys[i] = uint256(map._inner._entries[i]._key);
+            }
+        }
+    }
+
+    function values(AddressToAddressMap storage map)
+        internal
+        view
+        returns (address[] memory values)
+    {
+        uint256 len = map._inner._entries.length;
+        values = new address[](len);
+        unchecked {
+            for (uint256 i; i < len; ++i) {
+                values[i] = address(
+                    uint160(uint256(map._inner._entries[i]._value))
+                );
+            }
+        }
+    }
+
+    function values(UintToAddressMap storage map)
+        internal
+        view
+        returns (address[] memory values)
+    {
+        uint256 len = map._inner._entries.length;
+        values = new address[](len);
+        unchecked {
+            for (uint256 i; i < len; ++i) {
+                values[i] = address(
+                    uint160(uint256(map._inner._entries[i]._value))
+                );
+            }
+        }
+    }
+
     function _at(Map storage map, uint256 index)
         private
         view

--- a/contracts/data/EnumerableMapAddressToAddressMock.sol
+++ b/contracts/data/EnumerableMapAddressToAddressMock.sol
@@ -32,4 +32,12 @@ contract EnumerableMapAddressToAddressMock {
     function remove(address key) external returns (bool) {
         return map.remove(key);
     }
+
+    function toArray()
+        external
+        view
+        returns (address[] memory keys, address[] memory values)
+    {
+        (keys, values) = map.toArray();
+    }
 }

--- a/contracts/data/EnumerableMapAddressToAddressMock.sol
+++ b/contracts/data/EnumerableMapAddressToAddressMock.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { EnumerableMap } from './EnumerableMap.sol';
+
+contract EnumerableMapAddressToAddressMock {
+    using EnumerableMap for EnumerableMap.AddressToAddressMap;
+
+    EnumerableMap.AddressToAddressMap internal map;
+
+    function at(uint256 index) external view returns (address, address) {
+        return map.at(index);
+    }
+
+    function contains(address key) external view returns (bool) {
+        return map.contains(key);
+    }
+
+    function length() external view returns (uint256) {
+        return map.length();
+    }
+
+    function get(address key) external view returns (address) {
+        return map.get(key);
+    }
+
+    function set(address key, address value) external returns (bool) {
+        return map.set(key, value);
+    }
+
+    function remove(address key) external returns (bool) {
+        return map.remove(key);
+    }
+}

--- a/contracts/data/EnumerableMapAddressToAddressMock.sol
+++ b/contracts/data/EnumerableMapAddressToAddressMock.sol
@@ -40,4 +40,12 @@ contract EnumerableMapAddressToAddressMock {
     {
         (keys, values) = map.toArray();
     }
+
+    function keys() external view returns (address[] memory keys) {
+        keys = map.keys();
+    }
+
+    function values() external view returns (address[] memory values) {
+        values = map.values();
+    }
 }

--- a/contracts/data/EnumerableMapUintToAddressMock.sol
+++ b/contracts/data/EnumerableMapUintToAddressMock.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { EnumerableMap } from './EnumerableMap.sol';
+
+contract EnumerableMapUintToAddressMock {
+    using EnumerableMap for EnumerableMap.UintToAddressMap;
+
+    EnumerableMap.UintToAddressMap internal map;
+
+    function at(uint256 index) external view returns (uint256, address) {
+        return map.at(index);
+    }
+
+    function contains(uint256 key) external view returns (bool) {
+        return map.contains(key);
+    }
+
+    function length() external view returns (uint256) {
+        return map.length();
+    }
+
+    function get(uint256 key) external view returns (address) {
+        return map.get(key);
+    }
+
+    function set(uint256 key, address value) external returns (bool) {
+        return map.set(key, value);
+    }
+
+    function remove(uint256 key) external returns (bool) {
+        return map.remove(key);
+    }
+}

--- a/contracts/data/EnumerableMapUintToAddressMock.sol
+++ b/contracts/data/EnumerableMapUintToAddressMock.sol
@@ -40,4 +40,12 @@ contract EnumerableMapUintToAddressMock {
     {
         (keys, values) = map.toArray();
     }
+
+    function keys() external view returns (uint256[] memory keys) {
+        keys = map.keys();
+    }
+
+    function values() external view returns (address[] memory values) {
+        values = map.values();
+    }
 }

--- a/contracts/data/EnumerableMapUintToAddressMock.sol
+++ b/contracts/data/EnumerableMapUintToAddressMock.sol
@@ -32,4 +32,12 @@ contract EnumerableMapUintToAddressMock {
     function remove(uint256 key) external returns (bool) {
         return map.remove(key);
     }
+
+    function toArray()
+        external
+        view
+        returns (uint256[] memory keys, address[] memory values)
+    {
+        (keys, values) = map.toArray();
+    }
 }

--- a/test/data/EnumerableMap.ts
+++ b/test/data/EnumerableMap.ts
@@ -1,0 +1,203 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { bnToBytes32, bnToAddress } from '@solidstate/library';
+import {
+  EnumerableMapAddressToAddressMock,
+  EnumerableMapAddressToAddressMock__factory,
+} from '@solidstate/typechain-types';
+import { expect } from 'chai';
+import { BigNumber } from 'ethers';
+import { ethers } from 'hardhat';
+
+describe('EnumerableMap', async () => {
+  describe('AddressToAddressMap', async () => {
+    let instance: EnumerableMapAddressToAddressMock;
+    let deployer: SignerWithAddress;
+
+    beforeEach(async () => {
+      [deployer] = await ethers.getSigners();
+      instance = await new EnumerableMapAddressToAddressMock__factory(
+        deployer,
+      ).deploy();
+    });
+
+    describe('__internal', () => {
+      const addressOne = bnToAddress(BigNumber.from('100'));
+      const addressTwo = bnToAddress(BigNumber.from('200'));
+      const addressThree = bnToAddress(BigNumber.from('300'));
+      const addressFour = bnToAddress(BigNumber.from('400'));
+      const addressFive = bnToAddress(BigNumber.from('500'));
+      const addressSix = bnToAddress(BigNumber.from('600'));
+
+      describe('#at(uint256)', () => {
+        it('returns value coresponding to index provided', async () => {
+          await instance['set(address,address)'](addressOne, addressFour);
+          await instance['set(address,address)'](addressTwo, addressFive);
+          await instance['set(address,address)'](addressThree, addressSix);
+
+          expect(await instance['at(uint256)'](0)).to.deep.equal([
+            addressOne,
+            addressFour,
+          ]);
+          expect(await instance['at(uint256)'](1)).to.deep.equal([
+            addressTwo,
+            addressFive,
+          ]);
+          expect(await instance['at(uint256)'](2)).to.deep.equal([
+            addressThree,
+            addressSix,
+          ]);
+        });
+
+        describe('reverts if', () => {
+          it('index is out of bounds', async () => {
+            await expect(
+              instance['at(uint256)'](0),
+            ).to.be.revertedWithCustomError(
+              instance,
+              'EnumerableMap__IndexOutOfBounds',
+            );
+          });
+        });
+      });
+
+      describe('#contains(address)', () => {
+        it('returns true if value has been added', async () => {
+          await instance['set(address,address)'](addressOne, addressFour);
+          await instance['set(address,address)'](addressTwo, addressFive);
+          await instance['set(address,address)'](addressThree, addressSix);
+
+          expect(await instance['contains(address)'](addressOne)).to.be.true;
+          expect(await instance['contains(address)'](addressTwo)).to.be.true;
+          expect(await instance['contains(address)'](addressThree)).to.be.true;
+        });
+
+        it('returns false if value has not been added', async () => {
+          expect(await instance['contains(address)'](addressFour)).to.be.false;
+        });
+      });
+
+      describe('#length()', () => {
+        it('returns length of enumerable map', async () => {
+          expect(await instance['length()']()).to.equal(0);
+
+          await instance['set(address,address)'](addressOne, addressFour);
+          expect(await instance['length()']()).to.equal(1);
+
+          await instance['set(address,address)'](addressTwo, addressFive);
+          expect(await instance['length()']()).to.equal(2);
+
+          await instance['set(address,address)'](addressThree, addressSix);
+          expect(await instance['length()']()).to.equal(3);
+
+          await instance['remove(address)'](addressThree);
+          expect(await instance['length()']()).to.equal(2);
+
+          await instance['remove(address)'](addressTwo);
+          expect(await instance['length()']()).to.equal(1);
+
+          await instance['remove(address)'](addressOne);
+          expect(await instance['length()']()).to.equal(0);
+        });
+      });
+
+      describe('#get(address)', () => {
+        it('returns address stored at key', async () => {
+          await instance['set(address,address)'](addressOne, addressFour);
+          await instance['set(address,address)'](addressTwo, addressFive);
+          await instance['set(address,address)'](addressThree, addressSix);
+
+          expect(await instance['get(address)'](addressOne)).to.eq(addressFour);
+          expect(await instance['get(address)'](addressTwo)).to.eq(addressFive);
+          expect(await instance['get(address)'](addressThree)).to.eq(
+            addressSix,
+          );
+        });
+
+        describe('reverts if', () => {
+          it('key does not exist', async () => {
+            await expect(
+              instance['get(address)'](addressOne),
+            ).to.be.revertedWithCustomError(
+              instance,
+              'EnumerableMap__NonExistentKey',
+            );
+          });
+        });
+      });
+
+      describe('#set(address,address)', () => {
+        it('sets the address value at address key', async () => {
+          await instance['set(address,address)'](addressOne, addressFour);
+          await instance['set(address,address)'](addressTwo, addressFive);
+          await instance['set(address,address)'](addressThree, addressSix);
+
+          expect(await instance['contains(address)'](addressOne)).to.be.true;
+          expect(await instance['contains(address)'](addressTwo)).to.be.true;
+          expect(await instance['contains(address)'](addressThree)).to.be.true;
+
+          expect(await instance['get(address)'](addressOne)).to.eq(addressFour);
+          expect(await instance['get(address)'](addressTwo)).to.eq(addressFive);
+          expect(await instance['get(address)'](addressThree)).to.eq(
+            addressSix,
+          );
+        });
+
+        it('returns true if address value is added at address key', async () => {
+          expect(
+            await instance.callStatic['set(address,address)'](
+              addressOne,
+              addressFour,
+            ),
+          ).to.be.true;
+        });
+      });
+
+      describe('#remove(address)', () => {
+        it('removes the address value at given address key', async () => {
+          await instance['set(address,address)'](addressOne, addressFour);
+          await instance['set(address,address)'](addressTwo, addressFive);
+          await instance['set(address,address)'](addressThree, addressSix);
+
+          expect(await instance['length()']()).to.eq(3);
+
+          await instance['remove(address)'](addressOne);
+          await expect(
+            instance['get(address)'](addressOne),
+          ).to.be.revertedWithCustomError(
+            instance,
+            'EnumerableMap__NonExistentKey',
+          );
+          expect(await instance['length()']()).to.eq(2);
+
+          await instance['remove(address)'](addressTwo);
+          await expect(
+            instance['get(address)'](addressTwo),
+          ).to.be.revertedWithCustomError(
+            instance,
+            'EnumerableMap__NonExistentKey',
+          );
+          expect(await instance['length()']()).to.eq(1);
+
+          await instance['remove(address)'](addressThree);
+          await expect(
+            instance['get(address)'](addressThree),
+          ).to.be.revertedWithCustomError(
+            instance,
+            'EnumerableMap__NonExistentKey',
+          );
+          expect(await instance['length()']()).to.eq(0);
+        });
+
+        it('returns true if address key removed', async () => {
+          await instance['set(address,address)'](addressOne, addressFour);
+          expect(await instance.callStatic['remove(address)'](addressOne)).to.be
+            .true;
+        });
+        it('returns false if address key does not exist', async () => {
+          expect(await instance.callStatic['remove(address)'](addressOne)).to.be
+            .false;
+        });
+      });
+    });
+  });
+});

--- a/test/data/EnumerableMap.ts
+++ b/test/data/EnumerableMap.ts
@@ -1,14 +1,16 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
-import { bnToBytes32, bnToAddress } from '@solidstate/library';
+import { bnToAddress } from '@solidstate/library';
 import {
   EnumerableMapAddressToAddressMock,
   EnumerableMapAddressToAddressMock__factory,
+  EnumerableMapUintToAddressMock,
+  EnumerableMapUintToAddressMock__factory,
 } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { BigNumber } from 'ethers';
 import { ethers } from 'hardhat';
 
-describe('EnumerableMap', async () => {
+describe('EnumerableMap', () => {
   describe('AddressToAddressMap', async () => {
     let instance: EnumerableMapAddressToAddressMock;
     let deployer: SignerWithAddress;
@@ -195,6 +197,205 @@ describe('EnumerableMap', async () => {
         });
         it('returns false if address key does not exist', async () => {
           expect(await instance.callStatic['remove(address)'](addressOne)).to.be
+            .false;
+        });
+      });
+    });
+  });
+
+  describe('UintToAddressMap', async () => {
+    let instance: EnumerableMapUintToAddressMock;
+    let deployer: SignerWithAddress;
+
+    beforeEach(async () => {
+      [deployer] = await ethers.getSigners();
+      instance = await new EnumerableMapUintToAddressMock__factory(
+        deployer,
+      ).deploy();
+    });
+
+    describe('__internal', () => {
+      const addressOne = bnToAddress(BigNumber.from('100'));
+      const addressTwo = bnToAddress(BigNumber.from('200'));
+      const addressThree = bnToAddress(BigNumber.from('300'));
+      const uintOne = BigNumber.from('1');
+      const uintTwo = BigNumber.from('2');
+      const uintThree = BigNumber.from('3');
+
+      describe('#at(uint256)', () => {
+        it('returns value coresponding to index provided', async () => {
+          await instance['set(uint256,address)'](uintOne, addressOne);
+          await instance['set(uint256,address)'](uintTwo, addressTwo);
+          await instance['set(uint256,address)'](uintThree, addressThree);
+
+          expect(await instance['at(uint256)'](0)).to.deep.equal([
+            uintOne,
+            addressOne,
+          ]);
+          expect(await instance['at(uint256)'](1)).to.deep.equal([
+            uintTwo,
+            addressTwo,
+          ]);
+          expect(await instance['at(uint256)'](2)).to.deep.equal([
+            uintThree,
+            addressThree,
+          ]);
+        });
+
+        describe('reverts if', () => {
+          it('index is out of bounds', async () => {
+            await expect(
+              instance['at(uint256)'](0),
+            ).to.be.revertedWithCustomError(
+              instance,
+              'EnumerableMap__IndexOutOfBounds',
+            );
+          });
+        });
+      });
+
+      describe('#contains(uint256)', () => {
+        it('returns true if value has been added', async () => {
+          await instance['set(uint256,address)'](uintOne, addressOne);
+          await instance['set(uint256,address)'](uintTwo, addressTwo);
+          await instance['set(uint256,address)'](uintThree, addressThree);
+
+          expect(await instance['contains(uint256)'](uintOne)).to.be.true;
+          expect(await instance['contains(uint256)'](uintTwo)).to.be.true;
+          expect(await instance['contains(uint256)'](uintThree)).to.be.true;
+        });
+
+        it('returns false if value has not been added', async () => {
+          expect(await instance['contains(uint256)'](uintOne)).to.be.false;
+        });
+      });
+
+      describe('#length()', () => {
+        it('returns length of enumerable map', async () => {
+          expect(await instance['length()']()).to.equal(0);
+
+          await instance['set(uint256,address)'](uintOne, addressOne);
+          expect(await instance['length()']()).to.equal(1);
+
+          await instance['set(uint256,address)'](uintTwo, addressTwo);
+          expect(await instance['length()']()).to.equal(2);
+
+          await instance['set(uint256,address)'](uintThree, addressThree);
+          expect(await instance['length()']()).to.equal(3);
+
+          await instance['remove(uint256)'](uintOne);
+          expect(await instance['length()']()).to.equal(2);
+
+          await instance['remove(uint256)'](uintTwo);
+          expect(await instance['length()']()).to.equal(1);
+
+          await instance['remove(uint256)'](uintThree);
+          expect(await instance['length()']()).to.equal(0);
+        });
+      });
+
+      describe('#get(uint256)', () => {
+        it('returns address stored at key', async () => {
+          await instance['set(uint256,address)'](uintOne, addressOne);
+          await instance['set(uint256,address)'](uintTwo, addressTwo);
+          await instance['set(uint256,address)'](uintThree, addressThree);
+
+          expect(await instance['get(uint256)'](uintOne)).to.eq(addressOne);
+          expect(await instance['get(uint256)'](uintTwo)).to.eq(addressTwo);
+          expect(await instance['get(uint256)'](uintThree)).to.eq(addressThree);
+        });
+
+        describe('reverts if', () => {
+          it('key does not exist', async () => {
+            await expect(
+              instance['get(uint256)'](uintOne),
+            ).to.be.revertedWithCustomError(
+              instance,
+              'EnumerableMap__NonExistentKey',
+            );
+          });
+        });
+      });
+
+      describe('#set(uint256,address)', () => {
+        it('sets the address value at uint256 key', async () => {
+          await instance['set(uint256,address)'](uintOne, addressOne);
+          await instance['set(uint256,address)'](uintTwo, addressTwo);
+          await instance['set(uint256,address)'](uintThree, addressThree);
+
+          expect(await instance['contains(uint256)'](uintOne)).to.be.true;
+          expect(await instance['contains(uint256)'](uintTwo)).to.be.true;
+          expect(await instance['contains(uint256)'](uintThree)).to.be.true;
+
+          expect(await instance['get(uint256)'](uintOne)).to.eq(addressOne);
+          expect(await instance['get(uint256)'](uintTwo)).to.eq(addressTwo);
+          expect(await instance['get(uint256)'](uintThree)).to.eq(addressThree);
+        });
+
+        it('returns true if address value is added at uint256 key', async () => {
+          expect(
+            await instance.callStatic['set(uint256,address)'](
+              uintOne,
+              addressOne,
+            ),
+          ).to.be.true;
+        });
+
+        it('returns false if address value is already added at uint256 key', async () => {
+          await instance['set(uint256,address)'](uintOne, addressOne);
+
+          expect(
+            await instance.callStatic['set(uint256,address)'](
+              uintOne,
+              addressOne,
+            ),
+          ).to.be.false;
+        });
+      });
+
+      describe('#remove(uint256)', () => {
+        it('removes the address value at given uint256 key', async () => {
+          await instance['set(uint256,address)'](uintOne, addressOne);
+          await instance['set(uint256,address)'](uintTwo, addressTwo);
+          await instance['set(uint256,address)'](uintThree, addressThree);
+
+          expect(await instance['length()']()).to.eq(3);
+
+          await instance['remove(uint256)'](uintOne);
+          await expect(
+            instance['get(uint256)'](uintOne),
+          ).to.be.revertedWithCustomError(
+            instance,
+            'EnumerableMap__NonExistentKey',
+          );
+          expect(await instance['length()']()).to.eq(2);
+
+          await instance['remove(uint256)'](uintTwo);
+          await expect(
+            instance['get(uint256)'](uintTwo),
+          ).to.be.revertedWithCustomError(
+            instance,
+            'EnumerableMap__NonExistentKey',
+          );
+          expect(await instance['length()']()).to.eq(1);
+
+          await instance['remove(uint256)'](uintThree);
+          await expect(
+            instance['get(uint256)'](uintThree),
+          ).to.be.revertedWithCustomError(
+            instance,
+            'EnumerableMap__NonExistentKey',
+          );
+          expect(await instance['length()']()).to.eq(0);
+        });
+
+        it('returns true if uint256 key removed', async () => {
+          await instance['set(uint256,address)'](uintOne, addressOne);
+          expect(await instance.callStatic['remove(uint256)'](uintOne)).to.be
+            .true;
+        });
+        it('returns false if uint256 key does not exist', async () => {
+          expect(await instance.callStatic['remove(uint256)'](uintOne)).to.be
             .false;
         });
       });

--- a/test/data/EnumerableMap.ts
+++ b/test/data/EnumerableMap.ts
@@ -33,27 +33,17 @@ describe('EnumerableMap', () => {
       describe('#at(uint256)', () => {
         it('returns value coresponding to index provided', async () => {
           await instance['set(address,address)'](addressOne, addressFour);
-          await instance['set(address,address)'](addressTwo, addressFive);
-          await instance['set(address,address)'](addressThree, addressSix);
 
-          expect(await instance['at(uint256)'](0)).to.deep.equal([
-            addressOne,
-            addressFour,
-          ]);
-          expect(await instance['at(uint256)'](1)).to.deep.equal([
-            addressTwo,
-            addressFive,
-          ]);
-          expect(await instance['at(uint256)'](2)).to.deep.equal([
-            addressThree,
-            addressSix,
-          ]);
+          const [key, value] = await instance.callStatic['at(uint256)'](0);
+
+          expect(key).to.equal(addressOne);
+          expect(value).to.equal(addressFour);
         });
 
         describe('reverts if', () => {
           it('index is out of bounds', async () => {
             await expect(
-              instance['at(uint256)'](0),
+              instance.callStatic['at(uint256)'](0),
             ).to.be.revertedWithCustomError(
               instance,
               'EnumerableMap__IndexOutOfBounds',
@@ -65,60 +55,54 @@ describe('EnumerableMap', () => {
       describe('#contains(address)', () => {
         it('returns true if value has been added', async () => {
           await instance['set(address,address)'](addressOne, addressFour);
-          await instance['set(address,address)'](addressTwo, addressFive);
-          await instance['set(address,address)'](addressThree, addressSix);
 
-          expect(await instance['contains(address)'](addressOne)).to.be.true;
-          expect(await instance['contains(address)'](addressTwo)).to.be.true;
-          expect(await instance['contains(address)'](addressThree)).to.be.true;
+          expect(await instance.callStatic['contains(address)'](addressOne)).to
+            .be.true;
         });
 
         it('returns false if value has not been added', async () => {
-          expect(await instance['contains(address)'](addressFour)).to.be.false;
+          expect(await instance.callStatic['contains(address)'](addressFour)).to
+            .be.false;
         });
       });
 
       describe('#length()', () => {
         it('returns length of enumerable map', async () => {
-          expect(await instance['length()']()).to.equal(0);
+          expect(await instance.callStatic['length()']()).to.equal(0);
 
           await instance['set(address,address)'](addressOne, addressFour);
-          expect(await instance['length()']()).to.equal(1);
+          expect(await instance.callStatic['length()']()).to.equal(1);
 
           await instance['set(address,address)'](addressTwo, addressFive);
-          expect(await instance['length()']()).to.equal(2);
+          expect(await instance.callStatic['length()']()).to.equal(2);
 
           await instance['set(address,address)'](addressThree, addressSix);
-          expect(await instance['length()']()).to.equal(3);
+          expect(await instance.callStatic['length()']()).to.equal(3);
 
           await instance['remove(address)'](addressThree);
-          expect(await instance['length()']()).to.equal(2);
+          expect(await instance.callStatic['length()']()).to.equal(2);
 
           await instance['remove(address)'](addressTwo);
-          expect(await instance['length()']()).to.equal(1);
+          expect(await instance.callStatic['length()']()).to.equal(1);
 
           await instance['remove(address)'](addressOne);
-          expect(await instance['length()']()).to.equal(0);
+          expect(await instance.callStatic['length()']()).to.equal(0);
         });
       });
 
       describe('#get(address)', () => {
         it('returns address stored at key', async () => {
           await instance['set(address,address)'](addressOne, addressFour);
-          await instance['set(address,address)'](addressTwo, addressFive);
-          await instance['set(address,address)'](addressThree, addressSix);
 
-          expect(await instance['get(address)'](addressOne)).to.eq(addressFour);
-          expect(await instance['get(address)'](addressTwo)).to.eq(addressFive);
-          expect(await instance['get(address)'](addressThree)).to.eq(
-            addressSix,
+          expect(await instance.callStatic['get(address)'](addressOne)).to.eq(
+            addressFour,
           );
         });
 
         describe('reverts if', () => {
           it('key does not exist', async () => {
             await expect(
-              instance['get(address)'](addressOne),
+              instance.callStatic['get(address)'](addressOne),
             ).to.be.revertedWithCustomError(
               instance,
               'EnumerableMap__NonExistentKey',
@@ -130,17 +114,11 @@ describe('EnumerableMap', () => {
       describe('#set(address,address)', () => {
         it('sets the address value at address key', async () => {
           await instance['set(address,address)'](addressOne, addressFour);
-          await instance['set(address,address)'](addressTwo, addressFive);
-          await instance['set(address,address)'](addressThree, addressSix);
 
-          expect(await instance['contains(address)'](addressOne)).to.be.true;
-          expect(await instance['contains(address)'](addressTwo)).to.be.true;
-          expect(await instance['contains(address)'](addressThree)).to.be.true;
-
-          expect(await instance['get(address)'](addressOne)).to.eq(addressFour);
-          expect(await instance['get(address)'](addressTwo)).to.eq(addressFive);
-          expect(await instance['get(address)'](addressThree)).to.eq(
-            addressSix,
+          expect(await instance.callStatic['contains(address)'](addressOne)).to
+            .be.true;
+          expect(await instance.callStatic['get(address)'](addressOne)).to.eq(
+            addressFour,
           );
         });
 
@@ -168,37 +146,17 @@ describe('EnumerableMap', () => {
       describe('#remove(address)', () => {
         it('removes the address value at given address key', async () => {
           await instance['set(address,address)'](addressOne, addressFour);
-          await instance['set(address,address)'](addressTwo, addressFive);
-          await instance['set(address,address)'](addressThree, addressSix);
 
-          expect(await instance['length()']()).to.eq(3);
+          expect(await instance.callStatic['length()']()).to.eq(1);
 
           await instance['remove(address)'](addressOne);
           await expect(
-            instance['get(address)'](addressOne),
+            instance.callStatic['get(address)'](addressOne),
           ).to.be.revertedWithCustomError(
             instance,
             'EnumerableMap__NonExistentKey',
           );
-          expect(await instance['length()']()).to.eq(2);
-
-          await instance['remove(address)'](addressTwo);
-          await expect(
-            instance['get(address)'](addressTwo),
-          ).to.be.revertedWithCustomError(
-            instance,
-            'EnumerableMap__NonExistentKey',
-          );
-          expect(await instance['length()']()).to.eq(1);
-
-          await instance['remove(address)'](addressThree);
-          await expect(
-            instance['get(address)'](addressThree),
-          ).to.be.revertedWithCustomError(
-            instance,
-            'EnumerableMap__NonExistentKey',
-          );
-          expect(await instance['length()']()).to.eq(0);
+          expect(await instance.callStatic['length()']()).to.eq(0);
         });
 
         it('returns true if address key removed', async () => {
@@ -226,37 +184,27 @@ describe('EnumerableMap', () => {
     });
 
     describe('__internal', () => {
-      const addressOne = bnToAddress(BigNumber.from('100'));
-      const addressTwo = bnToAddress(BigNumber.from('200'));
-      const addressThree = bnToAddress(BigNumber.from('300'));
       const uintOne = BigNumber.from('1');
       const uintTwo = BigNumber.from('2');
       const uintThree = BigNumber.from('3');
+      const addressOne = bnToAddress(BigNumber.from('100'));
+      const addressTwo = bnToAddress(BigNumber.from('200'));
+      const addressThree = bnToAddress(BigNumber.from('300'));
 
       describe('#at(uint256)', () => {
         it('returns value coresponding to index provided', async () => {
           await instance['set(uint256,address)'](uintOne, addressOne);
-          await instance['set(uint256,address)'](uintTwo, addressTwo);
-          await instance['set(uint256,address)'](uintThree, addressThree);
 
-          expect(await instance['at(uint256)'](0)).to.deep.equal([
-            uintOne,
-            addressOne,
-          ]);
-          expect(await instance['at(uint256)'](1)).to.deep.equal([
-            uintTwo,
-            addressTwo,
-          ]);
-          expect(await instance['at(uint256)'](2)).to.deep.equal([
-            uintThree,
-            addressThree,
-          ]);
+          const [key, value] = await instance.callStatic['at(uint256)'](0);
+
+          expect(key).to.equal(uintOne);
+          expect(value).to.equal(addressOne);
         });
 
         describe('reverts if', () => {
           it('index is out of bounds', async () => {
             await expect(
-              instance['at(uint256)'](0),
+              instance.callStatic['at(uint256)'](0),
             ).to.be.revertedWithCustomError(
               instance,
               'EnumerableMap__IndexOutOfBounds',
@@ -268,58 +216,54 @@ describe('EnumerableMap', () => {
       describe('#contains(uint256)', () => {
         it('returns true if value has been added', async () => {
           await instance['set(uint256,address)'](uintOne, addressOne);
-          await instance['set(uint256,address)'](uintTwo, addressTwo);
-          await instance['set(uint256,address)'](uintThree, addressThree);
 
-          expect(await instance['contains(uint256)'](uintOne)).to.be.true;
-          expect(await instance['contains(uint256)'](uintTwo)).to.be.true;
-          expect(await instance['contains(uint256)'](uintThree)).to.be.true;
+          expect(await instance.callStatic['contains(uint256)'](uintOne)).to.be
+            .true;
         });
 
         it('returns false if value has not been added', async () => {
-          expect(await instance['contains(uint256)'](uintOne)).to.be.false;
+          expect(await instance.callStatic['contains(uint256)'](uintOne)).to.be
+            .false;
         });
       });
 
       describe('#length()', () => {
         it('returns length of enumerable map', async () => {
-          expect(await instance['length()']()).to.equal(0);
+          expect(await instance.callStatic['length()']()).to.equal(0);
 
           await instance['set(uint256,address)'](uintOne, addressOne);
-          expect(await instance['length()']()).to.equal(1);
+          expect(await instance.callStatic['length()']()).to.equal(1);
 
           await instance['set(uint256,address)'](uintTwo, addressTwo);
-          expect(await instance['length()']()).to.equal(2);
+          expect(await instance.callStatic['length()']()).to.equal(2);
 
           await instance['set(uint256,address)'](uintThree, addressThree);
-          expect(await instance['length()']()).to.equal(3);
+          expect(await instance.callStatic['length()']()).to.equal(3);
 
           await instance['remove(uint256)'](uintOne);
-          expect(await instance['length()']()).to.equal(2);
+          expect(await instance.callStatic['length()']()).to.equal(2);
 
           await instance['remove(uint256)'](uintTwo);
-          expect(await instance['length()']()).to.equal(1);
+          expect(await instance.callStatic['length()']()).to.equal(1);
 
           await instance['remove(uint256)'](uintThree);
-          expect(await instance['length()']()).to.equal(0);
+          expect(await instance.callStatic['length()']()).to.equal(0);
         });
       });
 
       describe('#get(uint256)', () => {
         it('returns address stored at key', async () => {
           await instance['set(uint256,address)'](uintOne, addressOne);
-          await instance['set(uint256,address)'](uintTwo, addressTwo);
-          await instance['set(uint256,address)'](uintThree, addressThree);
 
-          expect(await instance['get(uint256)'](uintOne)).to.eq(addressOne);
-          expect(await instance['get(uint256)'](uintTwo)).to.eq(addressTwo);
-          expect(await instance['get(uint256)'](uintThree)).to.eq(addressThree);
+          expect(await instance.callStatic['get(uint256)'](uintOne)).to.eq(
+            addressOne,
+          );
         });
 
         describe('reverts if', () => {
           it('key does not exist', async () => {
             await expect(
-              instance['get(uint256)'](uintOne),
+              instance.callStatic['get(uint256)'](uintOne),
             ).to.be.revertedWithCustomError(
               instance,
               'EnumerableMap__NonExistentKey',
@@ -331,16 +275,12 @@ describe('EnumerableMap', () => {
       describe('#set(uint256,address)', () => {
         it('sets the address value at uint256 key', async () => {
           await instance['set(uint256,address)'](uintOne, addressOne);
-          await instance['set(uint256,address)'](uintTwo, addressTwo);
-          await instance['set(uint256,address)'](uintThree, addressThree);
 
-          expect(await instance['contains(uint256)'](uintOne)).to.be.true;
-          expect(await instance['contains(uint256)'](uintTwo)).to.be.true;
-          expect(await instance['contains(uint256)'](uintThree)).to.be.true;
-
-          expect(await instance['get(uint256)'](uintOne)).to.eq(addressOne);
-          expect(await instance['get(uint256)'](uintTwo)).to.eq(addressTwo);
-          expect(await instance['get(uint256)'](uintThree)).to.eq(addressThree);
+          expect(await instance.callStatic['contains(uint256)'](uintOne)).to.be
+            .true;
+          expect(await instance.callStatic['get(uint256)'](uintOne)).to.eq(
+            addressOne,
+          );
         });
 
         it('returns true if address value is added at uint256 key', async () => {
@@ -367,37 +307,16 @@ describe('EnumerableMap', () => {
       describe('#remove(uint256)', () => {
         it('removes the address value at given uint256 key', async () => {
           await instance['set(uint256,address)'](uintOne, addressOne);
-          await instance['set(uint256,address)'](uintTwo, addressTwo);
-          await instance['set(uint256,address)'](uintThree, addressThree);
 
-          expect(await instance['length()']()).to.eq(3);
+          expect(await instance.callStatic['length()']()).to.eq(1);
 
           await instance['remove(uint256)'](uintOne);
           await expect(
-            instance['get(uint256)'](uintOne),
+            instance.callStatic['get(uint256)'](uintOne),
           ).to.be.revertedWithCustomError(
             instance,
             'EnumerableMap__NonExistentKey',
           );
-          expect(await instance['length()']()).to.eq(2);
-
-          await instance['remove(uint256)'](uintTwo);
-          await expect(
-            instance['get(uint256)'](uintTwo),
-          ).to.be.revertedWithCustomError(
-            instance,
-            'EnumerableMap__NonExistentKey',
-          );
-          expect(await instance['length()']()).to.eq(1);
-
-          await instance['remove(uint256)'](uintThree);
-          await expect(
-            instance['get(uint256)'](uintThree),
-          ).to.be.revertedWithCustomError(
-            instance,
-            'EnumerableMap__NonExistentKey',
-          );
-          expect(await instance['length()']()).to.eq(0);
         });
 
         it('returns true if uint256 key removed', async () => {

--- a/test/data/EnumerableMap.ts
+++ b/test/data/EnumerableMap.ts
@@ -187,6 +187,19 @@ describe('EnumerableMap', () => {
             .false;
         });
       });
+
+      describe('#toArray()', () => {
+        it('returns arrays of keys and values in map', async () => {
+          await instance['set(address,address)'](addressOne, addressFour);
+          await instance['set(address,address)'](addressTwo, addressFive);
+          await instance['set(address,address)'](addressThree, addressSix);
+
+          const [keys, values] = await instance.callStatic['toArray()']();
+
+          expect(keys).to.deep.equal([addressOne, addressTwo, addressThree]);
+          expect(values).to.deep.equal([addressFour, addressFive, addressSix]);
+        });
+      });
     });
   });
 
@@ -363,6 +376,19 @@ describe('EnumerableMap', () => {
         it('returns false if uint256 key does not exist', async () => {
           expect(await instance.callStatic['remove(uint256)'](uintOne)).to.be
             .false;
+        });
+      });
+
+      describe('#toArray()', () => {
+        it('returns arrays of keys and values in map', async () => {
+          await instance['set(uint256,address)'](uintOne, addressOne);
+          await instance['set(uint256,address)'](uintTwo, addressTwo);
+          await instance['set(uint256,address)'](uintThree, addressThree);
+
+          const [keys, values] = await instance.callStatic['toArray()']();
+
+          expect(keys).to.deep.equal([uintOne, uintTwo, uintThree]);
+          expect(values).to.deep.equal([addressOne, addressTwo, addressThree]);
         });
       });
     });

--- a/test/data/EnumerableMap.ts
+++ b/test/data/EnumerableMap.ts
@@ -122,6 +122,24 @@ describe('EnumerableMap', () => {
           );
         });
 
+        it('does not increase length if overwriting value at already set key', async () => {
+          await instance['set(address,address)'](addressOne, addressThree);
+          expect(await instance.callStatic['length()']()).to.eq(1);
+          await instance['set(address,address)'](addressOne, addressTwo);
+          expect(await instance.callStatic['length()']()).to.eq(1);
+        });
+
+        it('overwrites value if key already set', async () => {
+          await instance['set(address,address)'](addressOne, addressThree);
+          let [key, value] = await instance.callStatic['at(uint256)'](0);
+          expect(key).to.eq(addressOne);
+          expect(value).to.eq(addressThree);
+          await instance['set(address,address)'](addressOne, addressFour);
+          [key, value] = await instance.callStatic['at(uint256)'](0);
+          expect(key).to.eq(addressOne);
+          expect(value).to.eq(addressFour);
+        });
+
         it('returns true if address value is added at address key', async () => {
           expect(
             await instance.callStatic['set(address,address)'](
@@ -281,6 +299,24 @@ describe('EnumerableMap', () => {
           expect(await instance.callStatic['get(uint256)'](uintOne)).to.eq(
             addressOne,
           );
+        });
+
+        it('does not increase length if overwriting value at already set key', async () => {
+          await instance['set(uint256,address)'](uintOne, addressThree);
+          expect(await instance.callStatic['length()']()).to.eq(1);
+          await instance['set(uint256,address)'](uintOne, addressTwo);
+          expect(await instance.callStatic['length()']()).to.eq(1);
+        });
+
+        it('overwrites value if key already set', async () => {
+          await instance['set(uint256,address)'](uintOne, addressThree);
+          let [key, value] = await instance.callStatic['at(uint256)'](0);
+          expect(key).to.eq(uintOne);
+          expect(value).to.eq(addressThree);
+          await instance['set(uint256,address)'](uintOne, addressTwo);
+          [key, value] = await instance.callStatic['at(uint256)'](0);
+          expect(key).to.eq(uintOne);
+          expect(value).to.eq(addressTwo);
         });
 
         it('returns true if address value is added at uint256 key', async () => {

--- a/test/data/EnumerableMap.ts
+++ b/test/data/EnumerableMap.ts
@@ -152,6 +152,17 @@ describe('EnumerableMap', () => {
             ),
           ).to.be.true;
         });
+
+        it('returns false if address value is already added at address key', async () => {
+          await instance['set(address,address)'](addressOne, addressFour);
+
+          expect(
+            await instance.callStatic['set(address,address)'](
+              addressOne,
+              addressFour,
+            ),
+          ).to.be.false;
+        });
       });
 
       describe('#remove(address)', () => {

--- a/test/data/EnumerableMap.ts
+++ b/test/data/EnumerableMap.ts
@@ -200,6 +200,30 @@ describe('EnumerableMap', () => {
           expect(values).to.deep.equal([addressFour, addressFive, addressSix]);
         });
       });
+
+      describe('#keys()', () => {
+        it('returns array of keys in map', async () => {
+          await instance['set(address,address)'](addressOne, addressFour);
+          await instance['set(address,address)'](addressTwo, addressFive);
+          await instance['set(address,address)'](addressThree, addressSix);
+
+          const keys = await instance.callStatic['keys()']();
+
+          expect(keys).to.deep.equal([addressOne, addressTwo, addressThree]);
+        });
+      });
+
+      describe('#values()', () => {
+        it('returns array of values in map', async () => {
+          await instance['set(address,address)'](addressOne, addressFour);
+          await instance['set(address,address)'](addressTwo, addressFive);
+          await instance['set(address,address)'](addressThree, addressSix);
+
+          const values = await instance.callStatic['values()']();
+
+          expect(values).to.deep.equal([addressFour, addressFive, addressSix]);
+        });
+      });
     });
   });
 
@@ -388,6 +412,30 @@ describe('EnumerableMap', () => {
           const [keys, values] = await instance.callStatic['toArray()']();
 
           expect(keys).to.deep.equal([uintOne, uintTwo, uintThree]);
+          expect(values).to.deep.equal([addressOne, addressTwo, addressThree]);
+        });
+      });
+
+      describe('#keys()', () => {
+        it('returns array of keys in map', async () => {
+          await instance['set(uint256,address)'](uintOne, addressOne);
+          await instance['set(uint256,address)'](uintTwo, addressTwo);
+          await instance['set(uint256,address)'](uintThree, addressThree);
+
+          const keys = await instance.callStatic['keys()']();
+
+          expect(keys).to.deep.equal([uintOne, uintTwo, uintThree]);
+        });
+      });
+
+      describe('#values()', () => {
+        it('returns array of values in map', async () => {
+          await instance['set(uint256,address)'](uintOne, addressOne);
+          await instance['set(uint256,address)'](uintTwo, addressTwo);
+          await instance['set(uint256,address)'](uintThree, addressThree);
+
+          const values = await instance.callStatic['values()']();
+
           expect(values).to.deep.equal([addressOne, addressTwo, addressThree]);
         });
       });


### PR DESCRIPTION
Contains:

- tests for EnumerableMap
- fix for `_at(AddressToAddressMap storage map, uint256 index)` function

Initially only for `AddressToAddressMap`, once passed initial scrutiny, the `UintToAddressMap` tests will be added.