### PR TITLE
Add `excessivelySafeCall` function

### DIFF
--- a/contracts/utils/AddressUtils.sol
+++ b/contracts/utils/AddressUtils.sol
@@ -69,6 +69,53 @@ library AddressUtils {
         return _functionCallWithValue(target, data, value, error);
     }
 
+    /**
+     * @notice execute arbitrary external call with limited gas usage and amount of copied return data
+     * @dev derived from https://github.com/nomad-xyz/ExcessivelySafeCall (MIT License)
+     * @param target recipient of call
+     * @param gasAmount gas allowance for call
+     * @param value native token value to include in call
+     * @param maxCopy maximum number of bytes to copy from return data
+     * @param data encoded call data
+     * @return success whether call is successful
+     * @return returnData copied return data
+     */
+    function excessivelySafeCall(
+        address target,
+        uint256 gasAmount,
+        uint256 value,
+        uint16 maxCopy,
+        bytes memory data
+    ) internal returns (bool success, bytes memory returnData) {
+        returnData = new bytes(maxCopy);
+
+        assembly {
+            // execute external call via assembly to avoid automatic copying of return data
+            success := call(
+                gasAmount,
+                target,
+                value,
+                add(data, 0x20),
+                mload(data),
+                0,
+                0
+            )
+
+            // determine whether to limit amount of data to copy
+            let toCopy := returndatasize()
+
+            if gt(toCopy, maxCopy) {
+                toCopy := maxCopy
+            }
+
+            // store the length of the copied bytes
+            mstore(returnData, toCopy)
+
+            // copy the bytes from returndata[0:toCopy]
+            returndatacopy(add(returnData, 0x20), 0, toCopy)
+        }
+    }
+
     function _functionCallWithValue(
         address target,
         bytes memory data,


### PR DESCRIPTION
closes #145

Imported from https://github.com/solidstate-network/layerzero-client.