### PR TITLE
Add virtual modifier to ERC721Base functions

### DIFF
--- a/contracts/token/ERC20/base/ERC20Base.sol
+++ b/contracts/token/ERC20/base/ERC20Base.sol
@@ -14,14 +14,14 @@ abstract contract ERC20Base is IERC20Base, ERC20BaseInternal {
     /**
      * @inheritdoc IERC20
      */
-    function totalSupply() public view returns (uint256) {
+    function totalSupply() external view returns (uint256) {
         return _totalSupply();
     }
 
     /**
      * @inheritdoc IERC20
      */
-    function balanceOf(address account) public view returns (uint256) {
+    function balanceOf(address account) external view returns (uint256) {
         return _balanceOf(account);
     }
 
@@ -31,21 +31,24 @@ abstract contract ERC20Base is IERC20Base, ERC20BaseInternal {
     function allowance(
         address holder,
         address spender
-    ) public view returns (uint256) {
+    ) external view returns (uint256) {
         return _allowance(holder, spender);
     }
 
     /**
      * @inheritdoc IERC20
      */
-    function approve(address spender, uint256 amount) public returns (bool) {
+    function approve(address spender, uint256 amount) external returns (bool) {
         return _approve(msg.sender, spender, amount);
     }
 
     /**
      * @inheritdoc IERC20
      */
-    function transfer(address recipient, uint256 amount) public returns (bool) {
+    function transfer(
+        address recipient,
+        uint256 amount
+    ) external returns (bool) {
         return _transfer(msg.sender, recipient, amount);
     }
 
@@ -56,7 +59,7 @@ abstract contract ERC20Base is IERC20Base, ERC20BaseInternal {
         address holder,
         address recipient,
         uint256 amount
-    ) public returns (bool) {
+    ) external returns (bool) {
         return _transferFrom(holder, recipient, amount);
     }
 }

--- a/contracts/token/ERC20/base/ERC20Base.sol
+++ b/contracts/token/ERC20/base/ERC20Base.sol
@@ -14,14 +14,14 @@ abstract contract ERC20Base is IERC20Base, ERC20BaseInternal {
     /**
      * @inheritdoc IERC20
      */
-    function totalSupply() public view virtual returns (uint256) {
+    function totalSupply() public view returns (uint256) {
         return _totalSupply();
     }
 
     /**
      * @inheritdoc IERC20
      */
-    function balanceOf(address account) public view virtual returns (uint256) {
+    function balanceOf(address account) public view returns (uint256) {
         return _balanceOf(account);
     }
 
@@ -31,27 +31,21 @@ abstract contract ERC20Base is IERC20Base, ERC20BaseInternal {
     function allowance(
         address holder,
         address spender
-    ) public view virtual returns (uint256) {
+    ) public view returns (uint256) {
         return _allowance(holder, spender);
     }
 
     /**
      * @inheritdoc IERC20
      */
-    function approve(
-        address spender,
-        uint256 amount
-    ) public virtual returns (bool) {
+    function approve(address spender, uint256 amount) public returns (bool) {
         return _approve(msg.sender, spender, amount);
     }
 
     /**
      * @inheritdoc IERC20
      */
-    function transfer(
-        address recipient,
-        uint256 amount
-    ) public virtual returns (bool) {
+    function transfer(address recipient, uint256 amount) public returns (bool) {
         return _transfer(msg.sender, recipient, amount);
     }
 
@@ -62,7 +56,7 @@ abstract contract ERC20Base is IERC20Base, ERC20BaseInternal {
         address holder,
         address recipient,
         uint256 amount
-    ) public virtual returns (bool) {
+    ) public returns (bool) {
         return _transferFrom(holder, recipient, amount);
     }
 }

--- a/contracts/token/ERC721/base/ERC721Base.sol
+++ b/contracts/token/ERC721/base/ERC721Base.sol
@@ -13,21 +13,21 @@ abstract contract ERC721Base is IERC721Base, ERC721BaseInternal {
     /**
      * @inheritdoc IERC721
      */
-    function balanceOf(address account) public view returns (uint256) {
+    function balanceOf(address account) external view returns (uint256) {
         return _balanceOf(account);
     }
 
     /**
      * @inheritdoc IERC721
      */
-    function ownerOf(uint256 tokenId) public view returns (address) {
+    function ownerOf(uint256 tokenId) external view returns (address) {
         return _ownerOf(tokenId);
     }
 
     /**
      * @inheritdoc IERC721
      */
-    function getApproved(uint256 tokenId) public view returns (address) {
+    function getApproved(uint256 tokenId) external view returns (address) {
         return _getApproved(tokenId);
     }
 
@@ -37,7 +37,7 @@ abstract contract ERC721Base is IERC721Base, ERC721BaseInternal {
     function isApprovedForAll(
         address account,
         address operator
-    ) public view returns (bool) {
+    ) external view returns (bool) {
         return _isApprovedForAll(account, operator);
     }
 
@@ -48,7 +48,7 @@ abstract contract ERC721Base is IERC721Base, ERC721BaseInternal {
         address from,
         address to,
         uint256 tokenId
-    ) public payable {
+    ) external payable {
         _transferFrom(from, to, tokenId);
     }
 
@@ -59,7 +59,7 @@ abstract contract ERC721Base is IERC721Base, ERC721BaseInternal {
         address from,
         address to,
         uint256 tokenId
-    ) public payable {
+    ) external payable {
         _safeTransferFrom(from, to, tokenId);
     }
 
@@ -71,21 +71,21 @@ abstract contract ERC721Base is IERC721Base, ERC721BaseInternal {
         address to,
         uint256 tokenId,
         bytes memory data
-    ) public payable {
+    ) external payable {
         _safeTransferFrom(from, to, tokenId, data);
     }
 
     /**
      * @inheritdoc IERC721
      */
-    function approve(address operator, uint256 tokenId) public payable {
+    function approve(address operator, uint256 tokenId) external payable {
         _approve(operator, tokenId);
     }
 
     /**
      * @inheritdoc IERC721
      */
-    function setApprovalForAll(address operator, bool status) public {
+    function setApprovalForAll(address operator, bool status) external {
         _setApprovalForAll(operator, status);
     }
 }

--- a/contracts/token/ERC721/base/ERC721Base.sol
+++ b/contracts/token/ERC721/base/ERC721Base.sol
@@ -22,23 +22,21 @@ abstract contract ERC721Base is IERC721Base, ERC721BaseInternal {
     /**
      * @inheritdoc IERC721
      */
-    function balanceOf(address account) public view virtual returns (uint256) {
+    function balanceOf(address account) public view returns (uint256) {
         return _balanceOf(account);
     }
 
     /**
      * @inheritdoc IERC721
      */
-    function ownerOf(uint256 tokenId) public view virtual returns (address) {
+    function ownerOf(uint256 tokenId) public view returns (address) {
         return _ownerOf(tokenId);
     }
 
     /**
      * @inheritdoc IERC721
      */
-    function getApproved(
-        uint256 tokenId
-    ) public view virtual returns (address) {
+    function getApproved(uint256 tokenId) public view returns (address) {
         return _getApproved(tokenId);
     }
 
@@ -48,7 +46,7 @@ abstract contract ERC721Base is IERC721Base, ERC721BaseInternal {
     function isApprovedForAll(
         address account,
         address operator
-    ) public view virtual returns (bool) {
+    ) public view returns (bool) {
         return _isApprovedForAll(account, operator);
     }
 
@@ -59,7 +57,7 @@ abstract contract ERC721Base is IERC721Base, ERC721BaseInternal {
         address from,
         address to,
         uint256 tokenId
-    ) public payable virtual {
+    ) public payable {
         _handleTransferMessageValue(from, to, tokenId, msg.value);
         if (!_isApprovedOrOwner(msg.sender, tokenId))
             revert ERC721Base__NotOwnerOrApproved();
@@ -73,7 +71,7 @@ abstract contract ERC721Base is IERC721Base, ERC721BaseInternal {
         address from,
         address to,
         uint256 tokenId
-    ) public payable virtual {
+    ) public payable {
         safeTransferFrom(from, to, tokenId, '');
     }
 
@@ -85,7 +83,7 @@ abstract contract ERC721Base is IERC721Base, ERC721BaseInternal {
         address to,
         uint256 tokenId,
         bytes memory data
-    ) public payable virtual {
+    ) public payable {
         _handleTransferMessageValue(from, to, tokenId, msg.value);
         if (!_isApprovedOrOwner(msg.sender, tokenId))
             revert ERC721Base__NotOwnerOrApproved();
@@ -95,7 +93,7 @@ abstract contract ERC721Base is IERC721Base, ERC721BaseInternal {
     /**
      * @inheritdoc IERC721
      */
-    function approve(address operator, uint256 tokenId) public payable virtual {
+    function approve(address operator, uint256 tokenId) public payable {
         _handleApproveMessageValue(operator, tokenId, msg.value);
         address owner = ownerOf(tokenId);
         if (operator == owner) revert ERC721Base__SelfApproval();
@@ -107,7 +105,7 @@ abstract contract ERC721Base is IERC721Base, ERC721BaseInternal {
     /**
      * @inheritdoc IERC721
      */
-    function setApprovalForAll(address operator, bool status) public virtual {
+    function setApprovalForAll(address operator, bool status) public {
         if (operator == msg.sender) revert ERC721Base__SelfApproval();
         ERC721BaseStorage.layout().operatorApprovals[msg.sender][
             operator

--- a/contracts/token/ERC721/base/ERC721Base.sol
+++ b/contracts/token/ERC721/base/ERC721Base.sol
@@ -3,22 +3,13 @@
 pragma solidity ^0.8.8;
 
 import { IERC721 } from '../../../interfaces/IERC721.sol';
-import { IERC721Receiver } from '../../../interfaces/IERC721Receiver.sol';
-import { EnumerableMap } from '../../../data/EnumerableMap.sol';
-import { EnumerableSet } from '../../../data/EnumerableSet.sol';
-import { AddressUtils } from '../../../utils/AddressUtils.sol';
 import { IERC721Base } from './IERC721Base.sol';
-import { ERC721BaseStorage } from './ERC721BaseStorage.sol';
 import { ERC721BaseInternal } from './ERC721BaseInternal.sol';
 
 /**
  * @title Base ERC721 implementation, excluding optional extensions
  */
 abstract contract ERC721Base is IERC721Base, ERC721BaseInternal {
-    using AddressUtils for address;
-    using EnumerableMap for EnumerableMap.UintToAddressMap;
-    using EnumerableSet for EnumerableSet.UintSet;
-
     /**
      * @inheritdoc IERC721
      */
@@ -58,10 +49,7 @@ abstract contract ERC721Base is IERC721Base, ERC721BaseInternal {
         address to,
         uint256 tokenId
     ) public payable {
-        _handleTransferMessageValue(from, to, tokenId, msg.value);
-        if (!_isApprovedOrOwner(msg.sender, tokenId))
-            revert ERC721Base__NotOwnerOrApproved();
-        _transfer(from, to, tokenId);
+        _transferFrom(from, to, tokenId);
     }
 
     /**
@@ -72,7 +60,7 @@ abstract contract ERC721Base is IERC721Base, ERC721BaseInternal {
         address to,
         uint256 tokenId
     ) public payable {
-        safeTransferFrom(from, to, tokenId, '');
+        _safeTransferFrom(from, to, tokenId);
     }
 
     /**
@@ -84,21 +72,13 @@ abstract contract ERC721Base is IERC721Base, ERC721BaseInternal {
         uint256 tokenId,
         bytes memory data
     ) public payable {
-        _handleTransferMessageValue(from, to, tokenId, msg.value);
-        if (!_isApprovedOrOwner(msg.sender, tokenId))
-            revert ERC721Base__NotOwnerOrApproved();
-        _safeTransfer(from, to, tokenId, data);
+        _safeTransferFrom(from, to, tokenId, data);
     }
 
     /**
      * @inheritdoc IERC721
      */
     function approve(address operator, uint256 tokenId) public payable {
-        _handleApproveMessageValue(operator, tokenId, msg.value);
-        address owner = ownerOf(tokenId);
-        if (operator == owner) revert ERC721Base__SelfApproval();
-        if (msg.sender != owner && !isApprovedForAll(owner, msg.sender))
-            revert ERC721Base__NotOwnerOrApproved();
         _approve(operator, tokenId);
     }
 
@@ -106,10 +86,6 @@ abstract contract ERC721Base is IERC721Base, ERC721BaseInternal {
      * @inheritdoc IERC721
      */
     function setApprovalForAll(address operator, bool status) public {
-        if (operator == msg.sender) revert ERC721Base__SelfApproval();
-        ERC721BaseStorage.layout().operatorApprovals[msg.sender][
-            operator
-        ] = status;
-        emit ApprovalForAll(msg.sender, operator, status);
+        _setApprovalForAll(operator, status);
     }
 }

--- a/contracts/token/ERC721/base/ERC721Base.sol
+++ b/contracts/token/ERC721/base/ERC721Base.sol
@@ -22,21 +22,23 @@ abstract contract ERC721Base is IERC721Base, ERC721BaseInternal {
     /**
      * @inheritdoc IERC721
      */
-    function balanceOf(address account) public view returns (uint256) {
+    function balanceOf(address account) public view virtual returns (uint256) {
         return _balanceOf(account);
     }
 
     /**
      * @inheritdoc IERC721
      */
-    function ownerOf(uint256 tokenId) public view returns (address) {
+    function ownerOf(uint256 tokenId) public view virtual returns (address) {
         return _ownerOf(tokenId);
     }
 
     /**
      * @inheritdoc IERC721
      */
-    function getApproved(uint256 tokenId) public view returns (address) {
+    function getApproved(
+        uint256 tokenId
+    ) public view virtual returns (address) {
         return _getApproved(tokenId);
     }
 
@@ -46,7 +48,7 @@ abstract contract ERC721Base is IERC721Base, ERC721BaseInternal {
     function isApprovedForAll(
         address account,
         address operator
-    ) public view returns (bool) {
+    ) public view virtual returns (bool) {
         return _isApprovedForAll(account, operator);
     }
 
@@ -57,7 +59,7 @@ abstract contract ERC721Base is IERC721Base, ERC721BaseInternal {
         address from,
         address to,
         uint256 tokenId
-    ) public payable {
+    ) public payable virtual {
         _handleTransferMessageValue(from, to, tokenId, msg.value);
         if (!_isApprovedOrOwner(msg.sender, tokenId))
             revert ERC721Base__NotOwnerOrApproved();
@@ -71,7 +73,7 @@ abstract contract ERC721Base is IERC721Base, ERC721BaseInternal {
         address from,
         address to,
         uint256 tokenId
-    ) public payable {
+    ) public payable virtual {
         safeTransferFrom(from, to, tokenId, '');
     }
 
@@ -83,7 +85,7 @@ abstract contract ERC721Base is IERC721Base, ERC721BaseInternal {
         address to,
         uint256 tokenId,
         bytes memory data
-    ) public payable {
+    ) public payable virtual {
         _handleTransferMessageValue(from, to, tokenId, msg.value);
         if (!_isApprovedOrOwner(msg.sender, tokenId))
             revert ERC721Base__NotOwnerOrApproved();
@@ -93,7 +95,7 @@ abstract contract ERC721Base is IERC721Base, ERC721BaseInternal {
     /**
      * @inheritdoc IERC721
      */
-    function approve(address operator, uint256 tokenId) public payable {
+    function approve(address operator, uint256 tokenId) public payable virtual {
         _handleApproveMessageValue(operator, tokenId, msg.value);
         address owner = ownerOf(tokenId);
         if (operator == owner) revert ERC721Base__SelfApproval();
@@ -105,7 +107,7 @@ abstract contract ERC721Base is IERC721Base, ERC721BaseInternal {
     /**
      * @inheritdoc IERC721
      */
-    function setApprovalForAll(address operator, bool status) public {
+    function setApprovalForAll(address operator, bool status) public virtual {
         if (operator == msg.sender) revert ERC721Base__SelfApproval();
         ERC721BaseStorage.layout().operatorApprovals[msg.sender][
             operator

--- a/contracts/token/ERC721/base/ERC721BaseInternal.sol
+++ b/contracts/token/ERC721/base/ERC721BaseInternal.sol
@@ -95,7 +95,7 @@ abstract contract ERC721BaseInternal is IERC721BaseInternal {
 
         _beforeTokenTransfer(owner, address(0), tokenId);
 
-        _approveInternal(address(0), tokenId);
+        _approve(owner, address(0), tokenId);
 
         ERC721BaseStorage.Layout storage l = ERC721BaseStorage.layout();
         l.holderTokens[owner].remove(tokenId);
@@ -109,12 +109,14 @@ abstract contract ERC721BaseInternal is IERC721BaseInternal {
         address to,
         uint256 tokenId
     ) internal virtual {
-        if (_ownerOf(tokenId) != from) revert ERC721Base__NotTokenOwner();
+        address owner = _ownerOf(tokenId);
+
+        if (owner != from) revert ERC721Base__NotTokenOwner();
         if (to == address(0)) revert ERC721Base__TransferToZeroAddress();
 
         _beforeTokenTransfer(from, to, tokenId);
 
-        _approveInternal(address(0), tokenId);
+        _approve(owner, address(0), tokenId);
 
         ERC721BaseStorage.Layout storage l = ERC721BaseStorage.layout();
         l.holderTokens[from].remove(tokenId);
@@ -168,19 +170,23 @@ abstract contract ERC721BaseInternal is IERC721BaseInternal {
 
     function _approve(address operator, uint256 tokenId) internal virtual {
         _handleApproveMessageValue(operator, tokenId, msg.value);
+
         address owner = _ownerOf(tokenId);
+
         if (operator == owner) revert ERC721Base__SelfApproval();
         if (msg.sender != owner && !_isApprovedForAll(owner, msg.sender))
             revert ERC721Base__NotOwnerOrApproved();
-        _approveInternal(operator, tokenId);
+
+        _approve(owner, operator, tokenId);
     }
 
-    function _approveInternal(
+    function _approve(
+        address owner,
         address operator,
         uint256 tokenId
     ) internal virtual {
         ERC721BaseStorage.layout().tokenApprovals[tokenId] = operator;
-        emit Approval(_ownerOf(tokenId), operator, tokenId);
+        emit Approval(owner, operator, tokenId);
     }
 
     function _setApprovalForAll(

--- a/contracts/token/ERC721/base/ERC721BaseInternal.sol
+++ b/contracts/token/ERC721/base/ERC721BaseInternal.sol
@@ -95,12 +95,14 @@ abstract contract ERC721BaseInternal is IERC721BaseInternal {
 
         _beforeTokenTransfer(owner, address(0), tokenId);
 
-        _approve(owner, address(0), tokenId);
-
         ERC721BaseStorage.Layout storage l = ERC721BaseStorage.layout();
+
         l.holderTokens[owner].remove(tokenId);
         l.tokenOwners.remove(tokenId);
 
+        l.tokenApprovals[tokenId] = address(0);
+
+        emit Approval(owner, address(0), tokenId);
         emit Transfer(owner, address(0), tokenId);
     }
 
@@ -116,13 +118,14 @@ abstract contract ERC721BaseInternal is IERC721BaseInternal {
 
         _beforeTokenTransfer(from, to, tokenId);
 
-        _approve(owner, address(0), tokenId);
-
         ERC721BaseStorage.Layout storage l = ERC721BaseStorage.layout();
+
         l.holderTokens[from].remove(tokenId);
         l.holderTokens[to].add(tokenId);
         l.tokenOwners.set(tokenId, to);
+        l.tokenApprovals[tokenId] = address(0);
 
+        emit Approval(owner, address(0), tokenId);
         emit Transfer(from, to, tokenId);
     }
 
@@ -177,14 +180,6 @@ abstract contract ERC721BaseInternal is IERC721BaseInternal {
         if (msg.sender != owner && !_isApprovedForAll(owner, msg.sender))
             revert ERC721Base__NotOwnerOrApproved();
 
-        _approve(owner, operator, tokenId);
-    }
-
-    function _approve(
-        address owner,
-        address operator,
-        uint256 tokenId
-    ) internal virtual {
         ERC721BaseStorage.layout().tokenApprovals[tokenId] = operator;
         emit Approval(owner, operator, tokenId);
     }

--- a/contracts/token/ERC721/base/ERC721BaseMock.sol
+++ b/contracts/token/ERC721/base/ERC721BaseMock.sol
@@ -52,10 +52,6 @@ contract ERC721BaseMock is ERC721Base, ERC165Base {
         _burn(tokenId);
     }
 
-    function __approve(address owner, address to, uint256 tokenId) external {
-        _approve(owner, to, tokenId);
-    }
-
     function checkOnERC721Received(
         address from,
         address to,

--- a/contracts/token/ERC721/base/ERC721BaseMock.sol
+++ b/contracts/token/ERC721/base/ERC721BaseMock.sol
@@ -52,9 +52,8 @@ contract ERC721BaseMock is ERC721Base, ERC165Base {
         _burn(tokenId);
     }
 
-    function __approve(address to, uint256 tokenId) external {
-        // TODO: fix function name
-        _approveInternal(to, tokenId);
+    function __approve(address owner, address to, uint256 tokenId) external {
+        _approve(owner, to, tokenId);
     }
 
     function checkOnERC721Received(

--- a/contracts/token/ERC721/base/ERC721BaseMock.sol
+++ b/contracts/token/ERC721/base/ERC721BaseMock.sol
@@ -53,7 +53,8 @@ contract ERC721BaseMock is ERC721Base, ERC165Base {
     }
 
     function __approve(address to, uint256 tokenId) external {
-        _approve(to, tokenId);
+        // TODO: fix function name
+        _approveInternal(to, tokenId);
     }
 
     function checkOnERC721Received(

--- a/test/token/ERC721/ERC721Base.ts
+++ b/test/token/ERC721/ERC721Base.ts
@@ -623,50 +623,6 @@ describe('ERC721Base', function () {
       });
     });
 
-    describe('#_approve(address,uint256)', function () {
-      it('grants approval to spend given token on behalf of holder', async function () {
-        const tokenId = ethers.constants.Two;
-        await instance.mint(holder.address, tokenId);
-
-        expect(await instance.callStatic.getApproved(tokenId)).to.equal(
-          ethers.constants.AddressZero,
-        );
-
-        await instance.__approve(spender.address, tokenId);
-
-        expect(await instance.callStatic.getApproved(tokenId)).to.equal(
-          spender.address,
-        );
-
-        await expect(
-          instance
-            .connect(spender)
-            .callStatic.transferFrom(holder.address, spender.address, tokenId),
-        ).not.to.be.reverted;
-
-        await instance
-          .connect(holder)
-          .approve(ethers.constants.AddressZero, tokenId);
-
-        await expect(
-          instance
-            .connect(spender)
-            .callStatic.transferFrom(holder.address, spender.address, tokenId),
-        ).to.be.reverted;
-      });
-
-      it('emits Approval event', async function () {
-        const tokenId = ethers.constants.Two;
-        await instance.mint(holder.address, tokenId);
-
-        await expect(
-          instance.connect(holder).__approve(spender.address, tokenId),
-        )
-          .to.emit(instance, 'Approval')
-          .withArgs(holder.address, spender.address, tokenId);
-      });
-    });
-
     describe('#_checkOnERC721Received(address,address,uint256,bytes)', function () {
       it('returns true if recipient is not a contract', async function () {
         expect(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1982,7 +1982,7 @@
   dependencies:
     axios "^0.24.0"
 
-"@solidstate/library@^0.0.49":
+"@solidstate/library@^0.0.50":
   version "0.0.0"
   uid ""
 


### PR DESCRIPTION
Recently OpenSea has announced the implementation of an operator filter registry: https://github.com/ProjectOpenSea/operator-filter-registry 

This will prevent collections from receiving creator fees if OpenSea cannot confirm compliance with the above, or if it is found that they are trading assets on non-approved addresses, by making creator fees optional on OpenSea:

"Starting January 2nd, 2023, Opensea will begin validating creator fee enforcement for new collections on all supported EVM chains. After January 2nd, 2023, if OpenSea is unable to validate enforcement, OpenSea will make creator fees optional for that collection. Older collections will continue to have their fees enforced on OpenSea, including on Ethereum Mainnet (previously, enforcement was already required on Ethereum Mainnet)."

Compliance with OpenSea requires overriding of basic ERC721 functions. It is likely that if SolidState-based ERC721 collections wish to trade on OpenSea, they will require the ability to override the `ERC721Base` to abide by the `Operator-filter-registry`. 

