### PR TITLE
Inherit `OwnableBehaviorArgs` into `DiamondWritableBehaviorArgs`

### DIFF
--- a/spec/proxy/diamond/writable/DiamondWritable.behavior.ts
+++ b/spec/proxy/diamond/writable/DiamondWritable.behavior.ts
@@ -1,15 +1,15 @@
-import { describeBehaviorOfERC165Base } from '../../../introspection';
+import { OwnableBehaviorArgs, describeBehaviorOfERC165Base } from '../../../';
 import { deployMockContract } from '@ethereum-waffle/mock-contract';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeFilter } from '@solidstate/library';
-import { IDiamondWritable } from '@solidstate/typechain-types';
+import {
+  IDiamondWritable,
+  IDiamondReadable__factory,
+} from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 
-export interface DiamondWritableBehaviorArgs {
-  getOwner: () => Promise<SignerWithAddress>;
-  getNonOwner: () => Promise<SignerWithAddress>;
-}
+export interface DiamondWritableBehaviorArgs extends OwnableBehaviorArgs {}
 
 export function describeBehaviorOfDiamondWritable(
   deploy: () => Promise<IDiamondWritable>,


### PR DESCRIPTION
Sharing these behavior arguments is probably ideal in most situations, but it might be more strictly correct to define new arguments `diamondCutter` and `nonDiamondCutter`, in case that role is not the same as the `owner` role.