### PR TITLE
`FacetCut` struct  in `IDiamondWriteableInternal` doesn't follow the Spec naming conventions

### DIFF
--- a/abi/DiamondWritable.json
+++ b/abi/DiamondWritable.json
@@ -56,7 +56,7 @@
         "components": [
           {
             "internalType": "address",
-            "name": "target",
+            "name": "facetAddress",
             "type": "address"
           },
           {
@@ -66,7 +66,7 @@
           },
           {
             "internalType": "bytes4[]",
-            "name": "selectors",
+            "name": "functionSelectors",
             "type": "bytes4[]"
           }
         ],
@@ -116,7 +116,7 @@
         "components": [
           {
             "internalType": "address",
-            "name": "target",
+            "name": "facetAddress",
             "type": "address"
           },
           {
@@ -126,7 +126,7 @@
           },
           {
             "internalType": "bytes4[]",
-            "name": "selectors",
+            "name": "functionSelectors",
             "type": "bytes4[]"
           }
         ],

--- a/abi/DiamondWritableInternal.json
+++ b/abi/DiamondWritableInternal.json
@@ -46,7 +46,7 @@
         "components": [
           {
             "internalType": "address",
-            "name": "target",
+            "name": "facetAddress",
             "type": "address"
           },
           {
@@ -56,7 +56,7 @@
           },
           {
             "internalType": "bytes4[]",
-            "name": "selectors",
+            "name": "functionSelectors",
             "type": "bytes4[]"
           }
         ],

--- a/abi/IDiamondWritable.json
+++ b/abi/IDiamondWritable.json
@@ -46,7 +46,7 @@
         "components": [
           {
             "internalType": "address",
-            "name": "target",
+            "name": "facetAddress",
             "type": "address"
           },
           {
@@ -56,7 +56,7 @@
           },
           {
             "internalType": "bytes4[]",
-            "name": "selectors",
+            "name": "functionSelectors",
             "type": "bytes4[]"
           }
         ],
@@ -87,7 +87,7 @@
         "components": [
           {
             "internalType": "address",
-            "name": "target",
+            "name": "facetAddress",
             "type": "address"
           },
           {
@@ -97,7 +97,7 @@
           },
           {
             "internalType": "bytes4[]",
-            "name": "selectors",
+            "name": "functionSelectors",
             "type": "bytes4[]"
           }
         ],

--- a/abi/IDiamondWritableInternal.json
+++ b/abi/IDiamondWritableInternal.json
@@ -46,7 +46,7 @@
         "components": [
           {
             "internalType": "address",
-            "name": "target",
+            "name": "facetAddress",
             "type": "address"
           },
           {
@@ -56,7 +56,7 @@
           },
           {
             "internalType": "bytes4[]",
-            "name": "selectors",
+            "name": "functionSelectors",
             "type": "bytes4[]"
           }
         ],

--- a/abi/ISolidStateDiamond.json
+++ b/abi/ISolidStateDiamond.json
@@ -51,7 +51,7 @@
         "components": [
           {
             "internalType": "address",
-            "name": "target",
+            "name": "facetAddress",
             "type": "address"
           },
           {
@@ -61,7 +61,7 @@
           },
           {
             "internalType": "bytes4[]",
-            "name": "selectors",
+            "name": "functionSelectors",
             "type": "bytes4[]"
           }
         ],
@@ -122,7 +122,7 @@
         "components": [
           {
             "internalType": "address",
-            "name": "target",
+            "name": "facetAddress",
             "type": "address"
           },
           {
@@ -132,7 +132,7 @@
           },
           {
             "internalType": "bytes4[]",
-            "name": "selectors",
+            "name": "functionSelectors",
             "type": "bytes4[]"
           }
         ],

--- a/abi/SolidStateDiamond.json
+++ b/abi/SolidStateDiamond.json
@@ -71,7 +71,7 @@
         "components": [
           {
             "internalType": "address",
-            "name": "target",
+            "name": "facetAddress",
             "type": "address"
           },
           {
@@ -81,7 +81,7 @@
           },
           {
             "internalType": "bytes4[]",
-            "name": "selectors",
+            "name": "functionSelectors",
             "type": "bytes4[]"
           }
         ],
@@ -142,7 +142,7 @@
         "components": [
           {
             "internalType": "address",
-            "name": "target",
+            "name": "facetAddress",
             "type": "address"
           },
           {
@@ -152,7 +152,7 @@
           },
           {
             "internalType": "bytes4[]",
-            "name": "selectors",
+            "name": "functionSelectors",
             "type": "bytes4[]"
           }
         ],

--- a/contracts/proxy/diamond/SolidStateDiamond.sol
+++ b/contracts/proxy/diamond/SolidStateDiamond.sol
@@ -77,9 +77,9 @@ abstract contract SolidStateDiamond is
         FacetCut[] memory facetCuts = new FacetCut[](1);
 
         facetCuts[0] = FacetCut({
-            target: address(this),
+            facetAddress: address(this),
             action: FacetCutAction.ADD,
-            selectors: selectors
+            functionSelectors: selectors
         });
 
         _diamondCut(facetCuts, address(0), '');

--- a/contracts/proxy/diamond/writable/DiamondWritableInternal.sol
+++ b/contracts/proxy/diamond/writable/DiamondWritableInternal.sol
@@ -42,7 +42,7 @@ abstract contract DiamondWritableInternal is IDiamondWritableInternal {
                 FacetCut memory facetCut = facetCuts[i];
                 FacetCutAction action = facetCut.action;
 
-                if (facetCut.selectors.length == 0)
+                if (facetCut.functionSelectors.length == 0)
                     revert DiamondWritable__SelectorNotSpecified();
 
                 if (action == FacetCutAction.ADD) {
@@ -86,12 +86,12 @@ abstract contract DiamondWritableInternal is IDiamondWritableInternal {
     ) internal returns (uint256, bytes32) {
         unchecked {
             if (
-                facetCut.target != address(this) &&
-                !facetCut.target.isContract()
+                facetCut.facetAddress != address(this) &&
+                !facetCut.facetAddress.isContract()
             ) revert DiamondWritable__TargetHasNoCode();
 
-            for (uint256 i; i < facetCut.selectors.length; i++) {
-                bytes4 selector = facetCut.selectors[i];
+            for (uint256 i; i < facetCut.functionSelectors.length; i++) {
+                bytes4 selector = facetCut.functionSelectors[i];
                 bytes32 oldFacet = l.facets[selector];
 
                 if (address(bytes20(oldFacet)) != address(0))
@@ -99,7 +99,7 @@ abstract contract DiamondWritableInternal is IDiamondWritableInternal {
 
                 // add facet for selector
                 l.facets[selector] =
-                    bytes20(facetCut.target) |
+                    bytes20(facetCut.facetAddress) |
                     bytes32(selectorCount);
                 uint256 selectorInSlotPosition = (selectorCount & 7) << 5;
 
@@ -129,14 +129,14 @@ abstract contract DiamondWritableInternal is IDiamondWritableInternal {
         FacetCut memory facetCut
     ) internal returns (uint256, bytes32) {
         unchecked {
-            if (facetCut.target != address(0))
+            if (facetCut.facetAddress != address(0))
                 revert DiamondWritable__RemoveTargetNotZeroAddress();
 
             uint256 selectorSlotCount = selectorCount >> 3;
             uint256 selectorInSlotIndex = selectorCount & 7;
 
-            for (uint256 i; i < facetCut.selectors.length; i++) {
-                bytes4 selector = facetCut.selectors[i];
+            for (uint256 i; i < facetCut.functionSelectors.length; i++) {
+                bytes4 selector = facetCut.functionSelectors[i];
                 bytes32 oldFacet = l.facets[selector];
 
                 if (address(bytes20(oldFacet)) == address(0))
@@ -217,11 +217,11 @@ abstract contract DiamondWritableInternal is IDiamondWritableInternal {
         FacetCut memory facetCut
     ) internal {
         unchecked {
-            if (!facetCut.target.isContract())
+            if (!facetCut.facetAddress.isContract())
                 revert DiamondWritable__TargetHasNoCode();
 
-            for (uint256 i; i < facetCut.selectors.length; i++) {
-                bytes4 selector = facetCut.selectors[i];
+            for (uint256 i; i < facetCut.functionSelectors.length; i++) {
+                bytes4 selector = facetCut.functionSelectors[i];
                 bytes32 oldFacet = l.facets[selector];
                 address oldFacetAddress = address(bytes20(oldFacet));
 
@@ -229,13 +229,13 @@ abstract contract DiamondWritableInternal is IDiamondWritableInternal {
                     revert DiamondWritable__SelectorNotFound();
                 if (oldFacetAddress == address(this))
                     revert DiamondWritable__SelectorIsImmutable();
-                if (oldFacetAddress == facetCut.target)
+                if (oldFacetAddress == facetCut.facetAddress)
                     revert DiamondWritable__ReplaceTargetIsIdentical();
 
                 // replace old facet address
                 l.facets[selector] =
                     (oldFacet & CLEAR_ADDRESS_MASK) |
-                    bytes20(facetCut.target);
+                    bytes20(facetCut.facetAddress);
             }
         }
     }

--- a/contracts/proxy/diamond/writable/IDiamondWritableInternal.sol
+++ b/contracts/proxy/diamond/writable/IDiamondWritableInternal.sol
@@ -21,8 +21,8 @@ interface IDiamondWritableInternal {
     error DiamondWritable__TargetHasNoCode();
 
     struct FacetCut {
-        address target;
+        address facetAddress;
         FacetCutAction action;
-        bytes4[] selectors;
+        bytes4[] functionSelectors;
     }
 }

--- a/spec/proxy/diamond/SolidStateDiamond.behavior.ts
+++ b/spec/proxy/diamond/SolidStateDiamond.behavior.ts
@@ -136,7 +136,10 @@ export function describeBehaviorOfSolidStateDiamond(
           ).to.be.revertedWith('Mock on the method is not initialized');
 
           expect(await instance.callStatic['facets()']()).to.have.deep.members([
-            ...args.facetCuts.map((fc) => [fc.target, fc.selectors]),
+            ...args.facetCuts.map((fc) => [
+              fc.facetAddress,
+              fc.functionSelectors,
+            ]),
             [facet.address, expectedSelectors],
           ]);
 
@@ -200,7 +203,10 @@ export function describeBehaviorOfSolidStateDiamond(
 
           expect(await instance.callStatic['facets()']()).to.have.deep.members(
             [
-              ...args.facetCuts.map((fc) => [fc.target, fc.selectors]),
+              ...args.facetCuts.map<[any, any[]]>((fc) => [
+                fc.facetAddress,
+                fc.functionSelectors,
+              ]),
               [facet.address, expectedSelectors],
             ].filter((f) => f[1].length),
           );
@@ -265,7 +271,10 @@ export function describeBehaviorOfSolidStateDiamond(
 
           expect(await instance.callStatic['facets()']()).to.have.deep.members(
             [
-              ...args.facetCuts.map((fc) => [fc.target, fc.selectors]),
+              ...args.facetCuts.map<[any, any[]]>((fc) => [
+                fc.facetAddress,
+                fc.functionSelectors,
+              ]),
               [facet.address, expectedSelectors],
             ].filter((f) => f[1].length),
           );
@@ -332,7 +341,10 @@ export function describeBehaviorOfSolidStateDiamond(
 
           expect(await instance.callStatic['facets()']()).to.have.deep.members(
             [
-              ...args.facetCuts.map((fc) => [fc.target, fc.selectors]),
+              ...args.facetCuts.map<[any, any[]]>((fc) => [
+                fc.facetAddress,
+                fc.functionSelectors,
+              ]),
               [facet.address, expectedSelectors],
             ].filter((f) => f[1].length),
           );

--- a/spec/proxy/diamond/SolidStateDiamond.behavior.ts
+++ b/spec/proxy/diamond/SolidStateDiamond.behavior.ts
@@ -92,7 +92,7 @@ export function describeBehaviorOfSolidStateDiamond(
     });
 
     describe('#diamondCut((address,enum,bytes4[])[],address,bytes)', function () {
-      const selectors: string[] = [];
+      const functionSelectors: string[] = [];
       const abi: string[] = [];
       let facet: MockContract;
 
@@ -100,7 +100,7 @@ export function describeBehaviorOfSolidStateDiamond(
         for (let i = 0; i < 24; i++) {
           const fn = `fn${i}()`;
           abi.push(`function ${fn}`);
-          selectors.push(
+          functionSelectors.push(
             ethers.utils.hexDataSlice(
               ethers.utils.solidityKeccak256(['string'], [fn]),
               0,
@@ -115,14 +115,18 @@ export function describeBehaviorOfSolidStateDiamond(
       it('adds selectors one-by-one', async function () {
         const expectedSelectors = [];
 
-        for (let selector of selectors) {
-          await instance
-            .connect(owner)
-            .diamondCut(
-              [{ target: facet.address, action: 0, selectors: [selector] }],
-              ethers.constants.AddressZero,
-              '0x',
-            );
+        for (let selector of functionSelectors) {
+          await instance.connect(owner).diamondCut(
+            [
+              {
+                facetAddress: facet.address,
+                action: 0,
+                functionSelectors: [selector],
+              },
+            ],
+            ethers.constants.AddressZero,
+            '0x',
+          );
 
           expectedSelectors.push(selector);
 
@@ -152,20 +156,20 @@ export function describeBehaviorOfSolidStateDiamond(
         await instance
           .connect(owner)
           .diamondCut(
-            [{ target: facet.address, action: 0, selectors }],
+            [{ facetAddress: facet.address, action: 0, functionSelectors }],
             ethers.constants.AddressZero,
             '0x',
           );
 
-        const expectedSelectors = [...selectors];
+        const expectedSelectors = [...functionSelectors];
 
-        for (let selector of selectors) {
+        for (let selector of functionSelectors) {
           await instance.connect(owner).diamondCut(
             [
               {
-                target: ethers.constants.AddressZero,
+                facetAddress: ethers.constants.AddressZero,
                 action: 2,
-                selectors: [selector],
+                functionSelectors: [selector],
               },
             ],
             ethers.constants.AddressZero,
@@ -217,20 +221,20 @@ export function describeBehaviorOfSolidStateDiamond(
         await instance
           .connect(owner)
           .diamondCut(
-            [{ target: facet.address, action: 0, selectors }],
+            [{ facetAddress: facet.address, action: 0, functionSelectors }],
             ethers.constants.AddressZero,
             '0x',
           );
 
-        const expectedSelectors = [...selectors];
+        const expectedSelectors = [...functionSelectors];
 
-        for (let selector of [...selectors].reverse()) {
+        for (let selector of [...functionSelectors].reverse()) {
           await instance.connect(owner).diamondCut(
             [
               {
-                target: ethers.constants.AddressZero,
+                facetAddress: ethers.constants.AddressZero,
                 action: 2,
-                selectors: [selector],
+                functionSelectors: [selector],
               },
             ],
             ethers.constants.AddressZero,
@@ -282,20 +286,22 @@ export function describeBehaviorOfSolidStateDiamond(
         await instance
           .connect(owner)
           .diamondCut(
-            [{ target: facet.address, action: 0, selectors }],
+            [{ facetAddress: facet.address, action: 0, functionSelectors }],
             ethers.constants.AddressZero,
             '0x',
           );
 
-        const expectedSelectors = [...selectors];
+        const expectedSelectors = [...functionSelectors];
 
-        for (let selector of [...selectors].sort(() => 0.5 - Math.random())) {
+        for (let selector of [...functionSelectors].sort(
+          () => 0.5 - Math.random(),
+        )) {
           await instance.connect(owner).diamondCut(
             [
               {
-                target: ethers.constants.AddressZero,
+                facetAddress: ethers.constants.AddressZero,
                 action: 2,
-                selectors: [selector],
+                functionSelectors: [selector],
               },
             ],
             ethers.constants.AddressZero,

--- a/spec/proxy/diamond/readable/DiamondReadable.behavior.ts
+++ b/spec/proxy/diamond/readable/DiamondReadable.behavior.ts
@@ -1,11 +1,14 @@
 import { describeBehaviorOfERC165Base } from '../../../introspection';
 import { describeFilter } from '@solidstate/library';
-import { IDiamondReadable } from '@solidstate/typechain-types';
+import {
+  IDiamondReadable,
+  IDiamondWritableInternal,
+} from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 
 export interface DiamondReadableBehaviorArgs {
-  facetCuts: any[];
+  facetCuts: IDiamondWritableInternal.FacetCutStruct[];
 }
 
 export function describeBehaviorOfDiamondReadable(
@@ -35,7 +38,7 @@ export function describeBehaviorOfDiamondReadable(
     describe('#facets()', function () {
       it('returns facet cuts', async function () {
         expect(await instance.callStatic['facets()']()).to.have.deep.members(
-          facetCuts.map((fc) => [fc.target, fc.selectors]),
+          facetCuts.map((fc) => [fc.facetAddress, fc.functionSelectors]),
         );
       });
     });
@@ -43,7 +46,7 @@ export function describeBehaviorOfDiamondReadable(
     describe('#facetAddresses()', function () {
       it('returns facets', async function () {
         expect(await instance.callStatic['facetAddresses()']()).to.have.members(
-          facetCuts.map((fc) => fc.target),
+          facetCuts.map((fc) => fc.facetAddress),
         );
       });
     });
@@ -53,9 +56,9 @@ export function describeBehaviorOfDiamondReadable(
         for (let facet of facetCuts) {
           expect(
             await instance.callStatic['facetFunctionSelectors(address)'](
-              facet.target,
+              facet.facetAddress,
             ),
-          ).to.have.members(facet.selectors);
+          ).to.have.members(facet.functionSelectors);
         }
       });
 
@@ -71,10 +74,10 @@ export function describeBehaviorOfDiamondReadable(
     describe('#facetAddress(bytes4)', function () {
       it('returns facet for given selector', async function () {
         for (let facet of facetCuts) {
-          for (let selector of facet.selectors) {
+          for (let selector of facet.functionSelectors) {
             expect(
               await instance.callStatic['facetAddress(bytes4)'](selector),
-            ).to.equal(facet.target);
+            ).to.equal(facet.facetAddress);
           }
         }
       });

--- a/spec/proxy/diamond/writable/DiamondWritable.behavior.ts
+++ b/spec/proxy/diamond/writable/DiamondWritable.behavior.ts
@@ -23,7 +23,7 @@ export function describeBehaviorOfDiamondWritable(
     let nonOwner: SignerWithAddress;
 
     const functions: string[] = [];
-    const selectors: string[] = [];
+    const functionSelectors: string[] = [];
     let abi: any;
     let facet: any;
 
@@ -36,7 +36,7 @@ export function describeBehaviorOfDiamondWritable(
       for (let i = 0; i < 24; i++) {
         const fn = `fn${i}()`;
         functions.push(fn);
-        selectors.push(
+        functionSelectors.push(
           ethers.utils.hexDataSlice(
             ethers.utils.solidityKeccak256(['string'], [fn]),
             0,
@@ -67,9 +67,11 @@ export function describeBehaviorOfDiamondWritable(
       it('emits DiamondCut event', async function () {
         const facets: any = [
           {
-            target: facet.address,
+            facetAddress: facet.address,
             action: 0,
-            selectors: [ethers.utils.hexlify(ethers.utils.randomBytes(4))],
+            functionSelectors: [
+              ethers.utils.hexlify(ethers.utils.randomBytes(4)),
+            ],
           },
         ];
         const target = ethers.constants.AddressZero;
@@ -110,7 +112,7 @@ export function describeBehaviorOfDiamondWritable(
           await instance
             .connect(owner)
             .diamondCut(
-              [{ target: facet.address, action: 0, selectors }],
+              [{ facetAddress: facet.address, action: 0, functionSelectors }],
               ethers.constants.AddressZero,
               '0x',
             );
@@ -129,9 +131,9 @@ export function describeBehaviorOfDiamondWritable(
               instance.connect(owner).diamondCut(
                 [
                   {
-                    target: ethers.constants.AddressZero,
+                    facetAddress: ethers.constants.AddressZero,
                     action: 0,
-                    selectors: [ethers.utils.randomBytes(4)],
+                    functionSelectors: [ethers.utils.randomBytes(4)],
                   },
                 ],
                 ethers.constants.AddressZero,
@@ -146,9 +148,9 @@ export function describeBehaviorOfDiamondWritable(
           it('selector has already been added', async function () {
             const facetCuts = [
               {
-                target: facet.address,
+                facetAddress: facet.address,
                 action: 0,
-                selectors: [ethers.utils.randomBytes(4)],
+                functionSelectors: [ethers.utils.randomBytes(4)],
               },
             ];
 
@@ -179,7 +181,7 @@ export function describeBehaviorOfDiamondWritable(
           await instance
             .connect(owner)
             .diamondCut(
-              [{ target: facet.address, action: 0, selectors }],
+              [{ facetAddress: facet.address, action: 0, functionSelectors }],
               ethers.constants.AddressZero,
               '0x',
             );
@@ -197,13 +199,17 @@ export function describeBehaviorOfDiamondWritable(
             expect(facetReplacement[fn]).not.to.be.undefined;
           }
 
-          await instance
-            .connect(owner)
-            .diamondCut(
-              [{ target: facetReplacement.address, action: 1, selectors }],
-              ethers.constants.AddressZero,
-              '0x',
-            );
+          await instance.connect(owner).diamondCut(
+            [
+              {
+                facetAddress: facetReplacement.address,
+                action: 1,
+                functionSelectors,
+              },
+            ],
+            ethers.constants.AddressZero,
+            '0x',
+          );
 
           for (let fn of functions) {
             // call reverts, but with mock-specific message
@@ -219,9 +225,9 @@ export function describeBehaviorOfDiamondWritable(
               instance.connect(owner).diamondCut(
                 [
                   {
-                    target: ethers.constants.AddressZero,
+                    facetAddress: ethers.constants.AddressZero,
                     action: 1,
-                    selectors: [ethers.utils.randomBytes(4)],
+                    functionSelectors: [ethers.utils.randomBytes(4)],
                   },
                 ],
                 ethers.constants.AddressZero,
@@ -238,9 +244,9 @@ export function describeBehaviorOfDiamondWritable(
               instance.connect(owner).diamondCut(
                 [
                   {
-                    target: facet.address,
+                    facetAddress: facet.address,
                     action: 1,
-                    selectors: [ethers.utils.randomBytes(4)],
+                    functionSelectors: [ethers.utils.randomBytes(4)],
                   },
                 ],
                 ethers.constants.AddressZero,
@@ -258,9 +264,9 @@ export function describeBehaviorOfDiamondWritable(
             await instance.connect(owner).diamondCut(
               [
                 {
-                  target: instance.address,
+                  facetAddress: instance.address,
                   action: 0,
-                  selectors: [selector],
+                  functionSelectors: [selector],
                 },
               ],
               ethers.constants.AddressZero,
@@ -271,9 +277,9 @@ export function describeBehaviorOfDiamondWritable(
               instance.connect(owner).diamondCut(
                 [
                   {
-                    target: facet.address,
+                    facetAddress: facet.address,
                     action: 1,
-                    selectors: [selector],
+                    functionSelectors: [selector],
                   },
                 ],
                 ethers.constants.AddressZero,
@@ -291,9 +297,9 @@ export function describeBehaviorOfDiamondWritable(
             await instance.connect(owner).diamondCut(
               [
                 {
-                  target: facet.address,
+                  facetAddress: facet.address,
                   action: 0,
-                  selectors: [selector],
+                  functionSelectors: [selector],
                 },
               ],
               ethers.constants.AddressZero,
@@ -304,9 +310,9 @@ export function describeBehaviorOfDiamondWritable(
               instance.connect(owner).diamondCut(
                 [
                   {
-                    target: facet.address,
+                    facetAddress: facet.address,
                     action: 1,
-                    selectors: [selector],
+                    functionSelectors: [selector],
                   },
                 ],
                 ethers.constants.AddressZero,
@@ -331,7 +337,7 @@ export function describeBehaviorOfDiamondWritable(
           await instance
             .connect(owner)
             .diamondCut(
-              [{ target: facet.address, action: 0, selectors }],
+              [{ facetAddress: facet.address, action: 0, functionSelectors }],
               ethers.constants.AddressZero,
               '0x',
             );
@@ -343,13 +349,17 @@ export function describeBehaviorOfDiamondWritable(
             );
           }
 
-          await instance
-            .connect(owner)
-            .diamondCut(
-              [{ target: ethers.constants.AddressZero, action: 2, selectors }],
-              ethers.constants.AddressZero,
-              '0x',
-            );
+          await instance.connect(owner).diamondCut(
+            [
+              {
+                facetAddress: ethers.constants.AddressZero,
+                action: 2,
+                functionSelectors,
+              },
+            ],
+            ethers.constants.AddressZero,
+            '0x',
+          );
 
           for (let fn of functions) {
             await expect(
@@ -367,9 +377,9 @@ export function describeBehaviorOfDiamondWritable(
               instance.connect(owner).diamondCut(
                 [
                   {
-                    target: instance.address,
+                    facetAddress: instance.address,
                     action: 2,
-                    selectors: [ethers.utils.randomBytes(4)],
+                    functionSelectors: [ethers.utils.randomBytes(4)],
                   },
                 ],
                 ethers.constants.AddressZero,
@@ -386,9 +396,9 @@ export function describeBehaviorOfDiamondWritable(
               instance.connect(owner).diamondCut(
                 [
                   {
-                    target: ethers.constants.AddressZero,
+                    facetAddress: ethers.constants.AddressZero,
                     action: 2,
-                    selectors: [ethers.utils.randomBytes(4)],
+                    functionSelectors: [ethers.utils.randomBytes(4)],
                   },
                 ],
                 ethers.constants.AddressZero,
@@ -406,9 +416,9 @@ export function describeBehaviorOfDiamondWritable(
             await instance.connect(owner).diamondCut(
               [
                 {
-                  target: instance.address,
+                  facetAddress: instance.address,
                   action: 0,
-                  selectors: [selector],
+                  functionSelectors: [selector],
                 },
               ],
               ethers.constants.AddressZero,
@@ -419,9 +429,9 @@ export function describeBehaviorOfDiamondWritable(
               instance.connect(owner).diamondCut(
                 [
                   {
-                    target: ethers.constants.AddressZero,
+                    facetAddress: ethers.constants.AddressZero,
                     action: 2,
-                    selectors: [selector],
+                    functionSelectors: [selector],
                   },
                 ],
                 ethers.constants.AddressZero,
@@ -449,9 +459,9 @@ export function describeBehaviorOfDiamondWritable(
             instance.connect(owner).diamondCut(
               [
                 {
-                  target: ethers.constants.AddressZero,
+                  facetAddress: ethers.constants.AddressZero,
                   action: 3,
-                  selectors: [],
+                  functionSelectors: [],
                 },
               ],
               ethers.constants.AddressZero,
@@ -465,9 +475,9 @@ export function describeBehaviorOfDiamondWritable(
             instance.connect(owner).diamondCut(
               [
                 {
-                  target: ethers.constants.AddressZero,
+                  facetAddress: ethers.constants.AddressZero,
                   action: 0,
-                  selectors: [],
+                  functionSelectors: [],
                 },
               ],
               ethers.constants.AddressZero,

--- a/test/proxy/diamond/SolidStateDiamond.ts
+++ b/test/proxy/diamond/SolidStateDiamond.ts
@@ -3,6 +3,7 @@ import { describeBehaviorOfSolidStateDiamond } from '@solidstate/spec';
 import {
   SolidStateDiamond,
   SolidStateDiamondMock__factory,
+  IDiamondWritableInternal,
 } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
@@ -14,7 +15,7 @@ describe('SolidStateDiamond', function () {
 
   let instance: SolidStateDiamond;
 
-  let facetCuts: any[] = [];
+  let facetCuts: IDiamondWritableInternal.FacetCutStruct[] = [];
 
   before(async function () {
     [owner, nomineeOwner, nonOwner] = await ethers.getSigners();
@@ -29,9 +30,9 @@ describe('SolidStateDiamond', function () {
     expect(facets).to.have.lengthOf(1);
 
     facetCuts[0] = {
-      target: instance.address,
+      facetAddress: instance.address,
       action: 0,
-      selectors: facets[0].selectors,
+      functionSelectors: facets[0].selectors,
     };
   });
 

--- a/test/proxy/diamond/base/DiamondBase.ts
+++ b/test/proxy/diamond/base/DiamondBase.ts
@@ -17,9 +17,9 @@ describe('DiamondBase', function () {
 
     instance = await new DiamondBaseMock__factory(deployer).deploy([
       {
-        target: facetInstance.address,
+        facetAddress: facetInstance.address,
         action: 0,
-        selectors: [facetInstance.interface.getSighash('owner()')],
+        functionSelectors: [facetInstance.interface.getSighash('owner()')],
       },
     ]);
   });

--- a/test/proxy/diamond/fallback/DiamondFallback.ts
+++ b/test/proxy/diamond/fallback/DiamondFallback.ts
@@ -24,9 +24,9 @@ describe('DiamondFallback', function () {
 
     instance = await new DiamondFallbackMock__factory(deployer).deploy([
       {
-        target: facetInstance.address,
+        facetAddress: facetInstance.address,
         action: 0,
-        selectors: [facetInstance.interface.getSighash('owner()')],
+        functionSelectors: [facetInstance.interface.getSighash('owner()')],
       },
     ]);
   });

--- a/test/proxy/diamond/readable/DiamondReadable.ts
+++ b/test/proxy/diamond/readable/DiamondReadable.ts
@@ -3,23 +3,24 @@ import { describeBehaviorOfDiamondReadable } from '@solidstate/spec';
 import {
   DiamondReadableMock,
   DiamondReadableMock__factory,
+  IDiamondWritableInternal,
 } from '@solidstate/typechain-types';
 import { ethers } from 'hardhat';
 
 describe('DiamondReadable', function () {
   let facet;
-  const facetCuts: any[] = [];
+  const facetCuts: IDiamondWritableInternal.FacetCutStruct[] = [];
 
   let instance: DiamondReadableMock;
 
   before(async function () {
     const functions = [];
-    const selectors = [];
+    const functionSelectors = [];
 
     for (let i = 0; i < 24; i++) {
       const fn = `fn${i}()`;
       functions.push(fn);
-      selectors.push(
+      functionSelectors.push(
         ethers.utils.hexDataSlice(
           ethers.utils.solidityKeccak256(['string'], [fn]),
           0,
@@ -34,9 +35,9 @@ describe('DiamondReadable', function () {
     facet = await deployMockContract(owner, abi);
 
     facetCuts.push({
-      target: facet.address,
+      facetAddress: facet.address,
       action: 0,
-      selectors,
+      functionSelectors,
     });
   });
 


### PR DESCRIPTION
The naming convention for the `FacetCut` struct does not follow the diamond [spec](https://eips.ethereum.org/EIPS/eip-2535), which uses a different naming convention `facetAddress` and `functionSelectors`:

https://github.com/solidstate-network/solidstate-solidity/blob/ae15a063728978ed30ddfd2b3faedb775307c417/contracts/proxy/diamond/writable/IDiamondWritableInternal.sol#L23-L28

This could potentially break client compatibility across diamonds. E.G. when I was porting over an ethers `diamondCut` script from another project, there were type errors with the SS Diamond.

This PR updates the codebase and tests to match the standard naming conventions.

I actually like the SS naming convention better, but it might be worth maintaining consistency with the standard.

**EDIT**: this also isn't a problem for everyone: I tested with louper, and their `diamondCut` still works with SS diamond despite using the spec naming convention, *because the ABI for the diamond they are referencing uses the same convention.

https://github.com/mark3labs/louper-v2/blob/d326c9ba4c48724297a6b8f5dcc9915d148ed250/src/lib/components/AddFacet.svelte#L41-L47


