### PR TITLE
Add virtual keyword to suportsInterface()

### DIFF
--- a/contracts/introspection/ERC165/base/ERC165Base.sol
+++ b/contracts/introspection/ERC165/base/ERC165Base.sol
@@ -14,7 +14,7 @@ abstract contract ERC165Base is IERC165Base, ERC165BaseInternal {
     /**
      * @inheritdoc IERC165
      */
-    function supportsInterface(bytes4 interfaceId) public view returns (bool) {
+    function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
         return _supportsInterface(interfaceId);
     }
 }


### PR DESCRIPTION
Add required virtual keyword to supportsInterface function in order to import ERCs like ERC721 into the diamond smart contract.

See [issue #194](https://github.com/solidstate-network/solidstate-solidity/issues/194) for more information.