### PR TITLE
Internal `ReentrancyGuard` functions

### DIFF
--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -18,10 +18,16 @@ abstract contract ReentrancyGuard {
         _unlockReentrancyGuard();
     }
 
+    /**
+     * @notice lock functions that use the nonReentrant modifier
+     */
     function _lockReentrancyGuard() internal virtual {
         ReentrancyGuardStorage.layout().status = 2;
     }
 
+    /**
+     * @noticer unlock funtions that use the nonReentrant modifier
+     */
     function _unlockReentrancyGuard() internal virtual {
         ReentrancyGuardStorage.layout().status = 1;
     }

--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -11,11 +11,18 @@ abstract contract ReentrancyGuard {
     error ReentrancyGuard__ReentrantCall();
 
     modifier nonReentrant() {
-        ReentrancyGuardStorage.Layout storage l = ReentrancyGuardStorage
-            .layout();
-        if (l.status == 2) revert ReentrancyGuard__ReentrantCall();
-        l.status = 2;
+        if (ReentrancyGuardStorage.layout().status == 2)
+            revert ReentrancyGuard__ReentrantCall();
+        _lockReentrancyGuard();
         _;
-        l.status = 1;
+        _unlockReentrancyGuard();
+    }
+
+    function _lockReentrancyGuard() internal virtual {
+        ReentrancyGuardStorage.layout().status = 2;
+    }
+
+    function _unlockReentrancyGuard() internal virtual {
+        ReentrancyGuardStorage.layout().status = 1;
     }
 }

--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -26,7 +26,7 @@ abstract contract ReentrancyGuard {
     }
 
     /**
-     * @noticer unlock funtions that use the nonReentrant modifier
+     * @notice unlock funtions that use the nonReentrant modifier
      */
     function _unlockReentrancyGuard() internal virtual {
         ReentrancyGuardStorage.layout().status = 1;

--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -10,8 +10,11 @@ import { ReentrancyGuardStorage } from './ReentrancyGuardStorage.sol';
 abstract contract ReentrancyGuard {
     error ReentrancyGuard__ReentrantCall();
 
+    uint256 internal constant REENTRANCY_STATUS_LOCKED = 2;
+    uint256 internal constant REENTRANCY_STATUS_UNLOCKED = 1;
+
     modifier nonReentrant() {
-        if (ReentrancyGuardStorage.layout().status == 2)
+        if (ReentrancyGuardStorage.layout().status == REENTRANCY_STATUS_LOCKED)
             revert ReentrancyGuard__ReentrantCall();
         _lockReentrancyGuard();
         _;
@@ -22,13 +25,13 @@ abstract contract ReentrancyGuard {
      * @notice lock functions that use the nonReentrant modifier
      */
     function _lockReentrancyGuard() internal virtual {
-        ReentrancyGuardStorage.layout().status = 2;
+        ReentrancyGuardStorage.layout().status = REENTRANCY_STATUS_LOCKED;
     }
 
     /**
      * @notice unlock funtions that use the nonReentrant modifier
      */
     function _unlockReentrancyGuard() internal virtual {
-        ReentrancyGuardStorage.layout().status = 1;
+        ReentrancyGuardStorage.layout().status = REENTRANCY_STATUS_UNLOCKED;
     }
 }


### PR DESCRIPTION
Slight increase in gas cost unless compiling with `viaIR` option.

New internal functions need tests.