### PR TITLE
Add enumerable functions to AccessControl

### DIFF
--- a/abi/AccessControl.json
+++ b/abi/AccessControl.json
@@ -1,6 +1,11 @@
 [
   {
     "inputs": [],
+    "name": "EnumerableSet__IndexOutOfBounds",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "UintUtils__InsufficientHexLength",
     "type": "error"
   },
@@ -93,6 +98,49 @@
         "internalType": "bytes32",
         "name": "",
         "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "getRoleMember",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleMemberCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",

--- a/abi/IAccessControl.json
+++ b/abi/IAccessControl.json
@@ -101,6 +101,49 @@
         "type": "bytes32"
       },
       {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "getRoleMember",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleMemberCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
         "internalType": "address",
         "name": "account",
         "type": "address"

--- a/contracts/access/access_control/AccessControl.sol
+++ b/contracts/access/access_control/AccessControl.sol
@@ -53,4 +53,21 @@ abstract contract AccessControl is IAccessControl, AccessControlInternal {
     function renounceRole(bytes32 role) external {
         _renounceRole(role);
     }
+
+    /**
+     * @inheritdoc IAccessControl
+     */
+    function getRoleMember(
+        bytes32 role,
+        uint256 index
+    ) external view returns (address) {
+        return _getRoleMember(role, index);
+    }
+
+    /**
+     * @inheritdoc IAccessControl
+     */
+    function getRoleMemberCount(bytes32 role) external view returns (uint256) {
+        return _getRoleMemberCount(role);
+    }
 }

--- a/contracts/access/access_control/AccessControlInternal.sol
+++ b/contracts/access/access_control/AccessControlInternal.sol
@@ -113,4 +113,26 @@ abstract contract AccessControlInternal is IAccessControlInternal {
     function _renounceRole(bytes32 role) internal virtual {
         _revokeRole(role, msg.sender);
     }
+
+    /**
+     * @notice query role for member at given index
+     * @param role role to query
+     * @param index index to query
+     */
+    function _getRoleMember(
+        bytes32 role,
+        uint256 index
+    ) internal view virtual returns (address) {
+        return AccessControlStorage.layout().roles[role].members.at(index);
+    }
+
+    /**
+     * @notice query role for member count
+     * @param role role to query
+     */
+    function _getRoleMemberCount(
+        bytes32 role
+    ) internal view virtual returns (uint256) {
+        return AccessControlStorage.layout().roles[role].members.length();
+    }
 }

--- a/contracts/access/access_control/IAccessControl.sol
+++ b/contracts/access/access_control/IAccessControl.sol
@@ -45,4 +45,27 @@ interface IAccessControl is IAccessControlInternal {
      * @param role role to relinquish
      */
     function renounceRole(bytes32 role) external;
+
+    /**
+     * @notice Returns one of the accounts that have `role`. `index` must be a
+     * value between 0 and {getRoleMemberCount}, non-inclusive.
+     *
+     * Role bearers are not sorted in any particular way, and their ordering may
+     * change at any point.
+     *
+     * WARNING: When using {getRoleMember} and {getRoleMemberCount}, make sure
+     * you perform all queries on the same block. See the following
+     * https://forum.openzeppelin.com/t/iterating-over-elements-on-enumerableset-in-openzeppelin-contracts/2296[forum post]
+     * for more information.
+     */
+    function getRoleMember(
+        bytes32 role,
+        uint256 index
+    ) external view returns (address);
+
+    /**
+     * @notice Returns the number of accounts that have `role`. Can be used
+     * together with {getRoleMember} to enumerate all bearers of a role.
+     */
+    function getRoleMemberCount(bytes32 role) external view returns (uint256);
 }

--- a/test/access/AccessControl.ts
+++ b/test/access/AccessControl.ts
@@ -14,10 +14,12 @@ const ROLE = ethers.utils.solidityKeccak256(['string'], ['ROLE']);
 describe('AccessControl', function () {
   let admin: SignerWithAddress;
   let nonAdmin: SignerWithAddress;
+  let nonAdmin2: SignerWithAddress;
+  let nonAdmin3: SignerWithAddress;
   let instance: AccessControlMock;
 
   before(async function () {
-    [admin, nonAdmin] = await ethers.getSigners();
+    [admin, nonAdmin, nonAdmin2, nonAdmin3] = await ethers.getSigners();
   });
 
   beforeEach(async function () {
@@ -101,6 +103,59 @@ describe('AccessControl', function () {
       await expect(instance.setRoleAdmin(ROLE, newAdminRole))
         .to.emit(instance, 'RoleAdminChanged')
         .withArgs(ROLE, DEFAULT_ADMIN_ROLE, newAdminRole);
+    });
+  });
+
+  describe('#_getRoleMember(bytes32,uint256)', function () {
+    it('returns the correct member', async function () {
+      await instance.connect(admin).grantRole(ROLE, nonAdmin.address);
+      await instance.connect(admin).grantRole(ROLE, nonAdmin2.address);
+      await instance.connect(admin).grantRole(ROLE, nonAdmin3.address);
+
+      expect(await instance.getRoleMember(ROLE, 0)).to.equal(nonAdmin.address);
+      expect(await instance.getRoleMember(ROLE, 1)).to.equal(nonAdmin2.address);
+      expect(await instance.getRoleMember(ROLE, 2)).to.equal(nonAdmin3.address);
+    });
+
+    describe('reverts if', function () {
+      it('role does not exist', async function () {
+        await instance.connect(admin).grantRole(ROLE, nonAdmin.address);
+
+        const newRole = ethers.utils.solidityKeccak256(
+          ['string'],
+          ['NEW_ROLE'],
+        );
+        await expect(
+          instance.getRoleMember(newRole, 0),
+        ).to.revertedWithCustomError(
+          instance,
+          'EnumerableSet__IndexOutOfBounds',
+        );
+      });
+
+      it('role exists but index is invalid', async function () {
+        await instance.connect(admin).grantRole(ROLE, nonAdmin.address);
+
+        await expect(
+          instance.getRoleMember(ROLE, 1),
+        ).to.revertedWithCustomError(
+          instance,
+          'EnumerableSet__IndexOutOfBounds',
+        );
+      });
+    });
+  });
+
+  describe('#_getRoleMemberCount(bytes32)', function () {
+    it('returns the correct count', async function () {
+      await instance.connect(admin).grantRole(ROLE, nonAdmin.address);
+      await instance.connect(admin).grantRole(ROLE, nonAdmin2.address);
+      await instance.connect(admin).grantRole(ROLE, nonAdmin3.address);
+
+      expect(await instance.getRoleMemberCount(ROLE)).to.equal(3);
+
+      const newRole = ethers.utils.solidityKeccak256(['string'], ['NEW_ROLE']);
+      expect(await instance.getRoleMemberCount(newRole)).to.equal(0);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1983,7 +1983,7 @@
   dependencies:
     axios "^0.24.0"
 
-"@solidstate/library@^0.0.54":
+"@solidstate/library@^0.0.56":
   version "0.0.0"
   uid ""
 


### PR DESCRIPTION
We add two new function, getRoleMember(role, index) and getRoleMemberCount(role) to AccessControl. The function and parameter names are borrowed from OpenZeppelin to make them familiar. These are quite lightweight, and AccessControlStorage already uses EnumerableSet, so it made sense to just add them to AccessControl instead of creating a new AccessControlEnumerable contract. We also add tests for positive and revert cases.