### PR TITLE
Make `_diamondCut` virtual

### DIFF
--- a/contracts/proxy/diamond/writable/DiamondWritableInternal.sol
+++ b/contracts/proxy/diamond/writable/DiamondWritableInternal.sol
@@ -24,7 +24,7 @@ abstract contract DiamondWritableInternal is IDiamondWritableInternal {
         FacetCut[] memory facetCuts,
         address target,
         bytes memory data
-    ) internal {
+    ) internal virtual {
         DiamondBaseStorage.Layout storage l = DiamondBaseStorage.layout();
 
         unchecked {


### PR DESCRIPTION
Motivation is to give users a path to implement  "finalizing" their diamond  (make them immutable) without having to eject from `SolidStateDiamond`, which is a very useful and easy-to-use default.

Related to https://github.com/solidstate-network/solidstate-solidity/issues/85.  I personally feel the desire to finalize diamonds may be more common than a power user feature. 

Making `diamondCut` virtual allows for the ability to conditionally revert on diamondCut if a "UpgradeabilityRevoked" flag is set somewhere, or other user specific conditions to finalize a diamond e.g. mutability expiration date etc...
