### PR TITLE
Fix Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,0 @@
-node_modules

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -2,5 +2,6 @@
   "semi": true,
   "singleQuote": true,
   "trailingComma": "all",
-  "bracketSpacing": true
+  "bracketSpacing": true,
+  "plugins": ["prettier-plugin-solidity"]
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,5 +3,8 @@
   "singleQuote": true,
   "trailingComma": "all",
   "bracketSpacing": true,
-  "plugins": ["prettier-plugin-solidity"]
+  "plugins": [
+    "prettier-plugin-solidity",
+    "@trivago/prettier-plugin-sort-imports"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lerna-publish": "yarn build && lerna publish && lerna run tsc-clean",
     "build": "hardhat compile && lerna run tsc",
     "prepare": "husky install",
-    "prettier": "prettier --write --ignore-path .gitignore .",
+    "prettier": "prettier --write .",
     "upgrade-dependencies": "yarn-up -e '@solidstate/library,@solidstate/spec,@solidstate/typechain-types' && yarn upgrade"
   },
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lerna-publish": "yarn build && lerna publish && lerna run tsc-clean",
     "build": "hardhat compile && lerna run tsc",
     "prepare": "husky install",
-    "prettier": "prettier --write .",
+    "prettier": "prettier --write --plugin=prettier-plugin-solidity .",
     "upgrade-dependencies": "yarn-up -e '@solidstate/library,@solidstate/spec,@solidstate/typechain-types' && yarn upgrade"
   },
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lerna-publish": "yarn build && lerna publish && lerna run tsc-clean",
     "build": "hardhat compile && lerna run tsc",
     "prepare": "husky install",
-    "prettier": "prettier --write --plugin=prettier-plugin-solidity .",
+    "prettier": "prettier --write --plugin=prettier-plugin-solidity --plugin=@trivago/prettier-plugin-sort-imports .",
     "upgrade-dependencies": "yarn-up -e '@solidstate/library,@solidstate/spec,@solidstate/typechain-types' && yarn upgrade"
   },
   "workspaces": [

--- a/spec/multisig/ECDSAMultisigWallet.behavior.ts
+++ b/spec/multisig/ECDSAMultisigWallet.behavior.ts
@@ -1,5 +1,5 @@
-import { deployMockContract } from '@solidstate/library';
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { deployMockContract } from '@solidstate/library';
 import { describeFilter, signData } from '@solidstate/library';
 import { IECDSAMultisigWallet } from '@solidstate/typechain-types';
 import { expect } from 'chai';

--- a/spec/proxy/diamond/SolidStateDiamond.behavior.ts
+++ b/spec/proxy/diamond/SolidStateDiamond.behavior.ts
@@ -19,8 +19,8 @@ import {
   describeBehaviorOfDiamondWritable,
   DiamondWritableBehaviorArgs,
 } from './writable/DiamondWritable.behavior';
-import { deployMockContract } from '@solidstate/library';
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { deployMockContract } from '@solidstate/library';
 import { describeFilter } from '@solidstate/library';
 import { ISolidStateDiamond } from '@solidstate/typechain-types';
 import { expect } from 'chai';

--- a/spec/proxy/diamond/fallback/DiamondFallback.behavior.ts
+++ b/spec/proxy/diamond/fallback/DiamondFallback.behavior.ts
@@ -1,6 +1,6 @@
 import { OwnableBehaviorArgs } from '../../../access/ownable/Ownable.behavior';
-import { deployMockContract } from '@solidstate/library';
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { deployMockContract } from '@solidstate/library';
 import { describeFilter } from '@solidstate/library';
 import {
   describeBehaviorOfDiamondBase,

--- a/spec/proxy/diamond/writable/DiamondWritable.behavior.ts
+++ b/spec/proxy/diamond/writable/DiamondWritable.behavior.ts
@@ -1,6 +1,6 @@
 import { OwnableBehaviorArgs, describeBehaviorOfERC165Base } from '../../../';
-import { deployMockContract } from '@solidstate/library';
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { deployMockContract } from '@solidstate/library';
 import { describeFilter } from '@solidstate/library';
 import {
   IDiamondWritable,

--- a/spec/proxy/upgradeable/UpgradeableProxyOwnable.behavior.ts
+++ b/spec/proxy/upgradeable/UpgradeableProxyOwnable.behavior.ts
@@ -2,8 +2,8 @@ import {
   describeBehaviorOfUpgradeableProxy,
   UpgradeableProxyBehaviorArgs,
 } from './UpgradeableProxy.behavior';
-import { deployMockContract } from '@solidstate/library';
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { deployMockContract } from '@solidstate/library';
 import { describeFilter } from '@solidstate/library';
 import { IUpgradeableProxyOwnable } from '@solidstate/typechain-types';
 import { expect } from 'chai';

--- a/spec/token/ERC1155/ERC1155Base.behavior.ts
+++ b/spec/token/ERC1155/ERC1155Base.behavior.ts
@@ -1,6 +1,6 @@
 import { describeBehaviorOfERC165Base } from '../../introspection';
-import { deployMockContract } from '@solidstate/library';
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { deployMockContract } from '@solidstate/library';
 import { describeFilter } from '@solidstate/library';
 import { IERC1155Base } from '@solidstate/typechain-types';
 import { expect } from 'chai';

--- a/spec/token/ERC20/ERC20Permit.behavior.ts
+++ b/spec/token/ERC20/ERC20Permit.behavior.ts
@@ -1,10 +1,10 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { time } from '@nomicfoundation/hardhat-network-helpers';
 import { describeFilter, signERC2612Permit } from '@solidstate/library';
 import { ERC20Permit } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ContractTransaction } from 'ethers';
 import { ethers } from 'hardhat';
-import { time } from '@nomicfoundation/hardhat-network-helpers';
 
 export interface ERC20PermitBehaviorArgs {
   allowance: (holder: string, spender: string) => Promise<bigint>;

--- a/spec/token/ERC721/ERC721Base.behavior.ts
+++ b/spec/token/ERC721/ERC721Base.behavior.ts
@@ -1,6 +1,6 @@
 import { describeBehaviorOfERC165Base } from '../../introspection';
-import { deployMockContract } from '@solidstate/library';
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { deployMockContract } from '@solidstate/library';
 import { describeFilter } from '@solidstate/library';
 import { ERC721Base } from '@solidstate/typechain-types';
 import { expect } from 'chai';

--- a/test/access/Ownable.ts
+++ b/test/access/Ownable.ts
@@ -1,10 +1,10 @@
-import { deployMockContract } from '@solidstate/library';
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { impersonateAccount } from '@nomicfoundation/hardhat-network-helpers';
+import { deployMockContract } from '@solidstate/library';
 import { describeBehaviorOfOwnable } from '@solidstate/spec';
 import { OwnableMock, OwnableMock__factory } from '@solidstate/typechain-types';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
-import { impersonateAccount } from '@nomicfoundation/hardhat-network-helpers';
 
 describe('Ownable', () => {
   let owner: SignerWithAddress;

--- a/test/token/ERC721/ERC721Base.ts
+++ b/test/token/ERC721/ERC721Base.ts
@@ -1,5 +1,5 @@
-import { deployMockContract } from '@solidstate/library';
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { deployMockContract } from '@solidstate/library';
 import { describeBehaviorOfERC721Base } from '@solidstate/spec';
 import {
   ERC721Base,

--- a/test/utils/AddressUtils.ts
+++ b/test/utils/AddressUtils.ts
@@ -1,5 +1,6 @@
-import { deployMockContract } from '@solidstate/library';
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { setBalance } from '@nomicfoundation/hardhat-network-helpers';
+import { deployMockContract } from '@solidstate/library';
 import {
   AddressUtilsMock,
   AddressUtilsMock__factory,
@@ -7,7 +8,6 @@ import {
 import { expect } from 'chai';
 import { BytesLike } from 'ethers';
 import { ethers } from 'hardhat';
-import { setBalance } from '@nomicfoundation/hardhat-network-helpers';
 
 describe('AddressUtils', async () => {
   let instance: AddressUtilsMock;


### PR DESCRIPTION
Prettier plugin handling seems to have changed during development of #220.  This branch properly imports both plugins in use.  However, CLI commands seem to ignore the `plugins` field of `.prettierrc.json`, so the plugins must be redundantly included in the yarn script.