### PR TITLE
Rename type conversion helpers

### DIFF
--- a/lib/bigint_conversion.ts
+++ b/lib/bigint_conversion.ts
@@ -9,7 +9,3 @@ export function bigintToAddress(bn: any) {
 export function bigintToBytes32(bn: any) {
   return ethers.zeroPadValue(ethers.toBeHex(bn), 32);
 }
-
-export function bytes32ToNumber(bytes32: any) {
-  return BigInt(bytes32);
-}

--- a/lib/bigint_conversion.ts
+++ b/lib/bigint_conversion.ts
@@ -2,11 +2,11 @@ import { ethers } from 'hardhat';
 
 // TODO: these no longer use bn and should be renamed or removed
 
-export function bnToAddress(bn: any) {
+export function bigintToAddress(bn: any) {
   return ethers.getAddress(ethers.zeroPadValue(ethers.toBeHex(bn), 20));
 }
 
-export function bnToBytes32(bn: any) {
+export function bigintToBytes32(bn: any) {
   return ethers.zeroPadValue(ethers.toBeHex(bn), 32);
 }
 

--- a/lib/bigint_conversion.ts
+++ b/lib/bigint_conversion.ts
@@ -1,7 +1,5 @@
 import { ethers } from 'hardhat';
 
-// TODO: these no longer use bn and should be renamed or removed
-
 export function bigintToAddress(bn: any) {
   return ethers.getAddress(ethers.zeroPadValue(ethers.toBeHex(bn), 20));
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
-export * from './bn_conversion';
+export * from './bigint_conversion';
 export * from './erc20_permit';
 export * from './mocha_describe_filter';
 export * from './mock_contract';

--- a/test/data/BinaryHeap.ts
+++ b/test/data/BinaryHeap.ts
@@ -16,8 +16,8 @@ import { ethers } from 'hardhat';
 const numbers = [0, 1, 2].map((n) => n);
 
 const constants = {
-  bytes32: numbers.map((n) => bnToBytes32(n)),
-  address: numbers.map((n) => bnToAddress(n)),
+  bytes32: numbers.map((n) => bigintToBytes32(n)),
+  address: numbers.map((n) => bigintToAddress(n)),
   uint256: numbers,
 };
 

--- a/test/data/BinaryHeap.ts
+++ b/test/data/BinaryHeap.ts
@@ -1,6 +1,6 @@
 import { PANIC_CODES } from '@nomicfoundation/hardhat-chai-matchers/panic';
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
-import { bnToBytes32, bnToAddress, bytes32ToNumber } from '@solidstate/library';
+import { bigintToBytes32, bigintToAddress } from '@solidstate/library';
 import {
   BinaryHeapAddressMock,
   BinaryHeapBytes32Mock,

--- a/test/data/DoublyLinkedList.ts
+++ b/test/data/DoublyLinkedList.ts
@@ -1,5 +1,5 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
-import { bnToBytes32, bnToAddress } from '@solidstate/library';
+import { bigintToBytes32, bigintToAddress } from '@solidstate/library';
 import {
   DoublyLinkedListBytes32Mock,
   DoublyLinkedListBytes32Mock__factory,
@@ -24,10 +24,10 @@ describe('DoublyLinkedList', async () => {
     });
 
     describe('__internal', () => {
-      const zeroBytes32 = bnToBytes32(0);
-      const oneBytes32 = bnToBytes32(1);
-      const twoBytes32 = bnToBytes32(2);
-      const threeBytes32 = bnToBytes32(3);
+      const zeroBytes32 = bigintToBytes32(0);
+      const oneBytes32 = bigintToBytes32(1);
+      const twoBytes32 = bigintToBytes32(2);
+      const threeBytes32 = bigintToBytes32(3);
 
       describe('#contains(bytes32)', () => {
         it('returns true if the value has been added', async () => {
@@ -370,7 +370,7 @@ describe('DoublyLinkedList', async () => {
         });
 
         it('replaces existing value with new value', async () => {
-          const newValue = bnToBytes32(4);
+          const newValue = bigintToBytes32(4);
 
           await instance.push(oneBytes32);
           await instance.push(twoBytes32);
@@ -440,10 +440,10 @@ describe('DoublyLinkedList', async () => {
     });
 
     describe('__internal', () => {
-      const zeroAddress = bnToAddress(0);
-      const oneAddress = bnToAddress(1);
-      const twoAddress = bnToAddress(2);
-      const threeAddress = bnToAddress(3);
+      const zeroAddress = bigintToAddress(0);
+      const oneAddress = bigintToAddress(1);
+      const twoAddress = bigintToAddress(2);
+      const threeAddress = bigintToAddress(3);
 
       describe('#contains(address)', () => {
         it('returns true if the value has been added', async () => {
@@ -786,7 +786,7 @@ describe('DoublyLinkedList', async () => {
         });
 
         it('replaces existing value with new value', async () => {
-          const newValue = bnToAddress(4);
+          const newValue = bigintToAddress(4);
 
           await instance.push(oneAddress);
           await instance.push(twoAddress);

--- a/test/data/EnumerableMap.ts
+++ b/test/data/EnumerableMap.ts
@@ -1,5 +1,5 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
-import { bnToAddress } from '@solidstate/library';
+import { bigintToAddress } from '@solidstate/library';
 import {
   EnumerableMapAddressToAddressMock,
   EnumerableMapAddressToAddressMock__factory,
@@ -22,12 +22,12 @@ describe('EnumerableMap', () => {
     });
 
     describe('__internal', () => {
-      const addressOne = bnToAddress(100);
-      const addressTwo = bnToAddress(200);
-      const addressThree = bnToAddress(300);
-      const addressFour = bnToAddress(400);
-      const addressFive = bnToAddress(500);
-      const addressSix = bnToAddress(600);
+      const addressOne = bigintToAddress(100);
+      const addressTwo = bigintToAddress(200);
+      const addressThree = bigintToAddress(300);
+      const addressFour = bigintToAddress(400);
+      const addressFive = bigintToAddress(500);
+      const addressSix = bigintToAddress(600);
 
       describe('#at(uint256)', () => {
         it('returns value coresponding to index provided', async () => {
@@ -224,9 +224,9 @@ describe('EnumerableMap', () => {
       const uintOne = 1;
       const uintTwo = 2;
       const uintThree = 3;
-      const addressOne = bnToAddress(100);
-      const addressTwo = bnToAddress(200);
-      const addressThree = bnToAddress(300);
+      const addressOne = bigintToAddress(100);
+      const addressTwo = bigintToAddress(200);
+      const addressThree = bigintToAddress(300);
 
       describe('#at(uint256)', () => {
         it('returns value coresponding to index provided', async () => {

--- a/test/data/EnumerableSet.ts
+++ b/test/data/EnumerableSet.ts
@@ -1,5 +1,5 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
-import { bnToBytes32, bnToAddress } from '@solidstate/library';
+import { bigintToBytes32, bigintToAddress } from '@solidstate/library';
 import {
   EnumerableSetBytes32Mock,
   EnumerableSetBytes32Mock__factory,
@@ -22,9 +22,9 @@ describe('EnumerableSet', async () => {
     });
 
     describe('__internal', () => {
-      const zeroBytes32 = bnToBytes32(0);
-      const oneBytes32 = bnToBytes32(1);
-      const twoBytes32 = bnToBytes32(2);
+      const zeroBytes32 = bigintToBytes32(0);
+      const oneBytes32 = bigintToBytes32(1);
+      const twoBytes32 = bigintToBytes32(2);
 
       describe('#at(uint256)', () => {
         it('returns the value corresponding to index provided', async () => {
@@ -196,9 +196,9 @@ describe('EnumerableSet', async () => {
     });
 
     describe('__internal', () => {
-      const zeroAddress = bnToAddress(0);
-      const oneAddress = bnToAddress(1);
-      const twoAddress = bnToAddress(2);
+      const zeroAddress = bigintToAddress(0);
+      const oneAddress = bigintToAddress(1);
+      const twoAddress = bigintToAddress(2);
 
       describe('#at(uint256)', () => {
         it('returns the value corresponding to index provided', async () => {

--- a/test/utils/ArrayUtils.ts
+++ b/test/utils/ArrayUtils.ts
@@ -1,5 +1,5 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
-import { bnToBytes32, bnToAddress } from '@solidstate/library';
+import { bigintToBytes32, bigintToAddress } from '@solidstate/library';
 import {
   ArrayUtilsMock,
   ArrayUtilsMock__factory,
@@ -21,16 +21,16 @@ describe('ArrayUtils', async () => {
       it('returns the minimum bytes32 value in given array', async () => {
         expect(
           await instance['min(bytes32[])'].staticCall([
-            bnToBytes32(1),
-            bnToBytes32(0),
-            bnToBytes32(2),
+            bigintToBytes32(1),
+            bigintToBytes32(0),
+            bigintToBytes32(2),
           ]),
-        ).to.equal(bnToBytes32(0));
+        ).to.equal(bigintToBytes32(0));
       });
 
       it('returns the max bytes32 value if array is empty', async () => {
         expect(await instance['min(bytes32[])'].staticCall([])).to.equal(
-          bnToBytes32(ethers.MaxUint256),
+          bigintToBytes32(ethers.MaxUint256),
         );
       });
     });
@@ -39,16 +39,16 @@ describe('ArrayUtils', async () => {
       it('returns the minimum address in given array', async () => {
         expect(
           await instance['min(address[])'].staticCall([
-            bnToAddress(1),
-            bnToAddress(0),
-            bnToAddress(2),
+            bigintToAddress(1),
+            bigintToAddress(0),
+            bigintToAddress(2),
           ]),
-        ).to.equal(bnToAddress(0));
+        ).to.equal(bigintToAddress(0));
       });
 
       it('returns the max address if array is empty', async () => {
         expect(await instance['min(address[])'].staticCall([])).to.equal(
-          bnToAddress(2n ** 160n - 1n),
+          bigintToAddress(2n ** 160n - 1n),
         );
       });
     });
@@ -71,11 +71,11 @@ describe('ArrayUtils', async () => {
       it('returns the maximum bytes32 value in given array', async () => {
         expect(
           await instance['max(bytes32[])'].staticCall([
-            bnToBytes32(1),
-            bnToBytes32(0),
-            bnToBytes32(2),
+            bigintToBytes32(1),
+            bigintToBytes32(0),
+            bigintToBytes32(2),
           ]),
-        ).to.equal(bnToBytes32(2));
+        ).to.equal(bigintToBytes32(2));
       });
 
       it('returns empty bytes if array is empty', async () => {
@@ -89,11 +89,11 @@ describe('ArrayUtils', async () => {
       it('returns the maximum address in given array', async () => {
         expect(
           await instance['max(address[])'].staticCall([
-            bnToAddress(1),
-            bnToAddress(0),
-            bnToAddress(2),
+            bigintToAddress(1),
+            bigintToAddress(0),
+            bigintToAddress(2),
           ]),
-        ).to.equal(bnToAddress(2));
+        ).to.equal(bigintToAddress(2));
       });
 
       it('returns zero address if array is empty', async () => {


### PR DESCRIPTION
Rename old "bn" conversion functions to better describe their new uses for interacting with native bigints.  Merging directly because no contract files are affected.