### PR TITLE
Upgrade minimum version of solc to ^0.8.18.

### DIFF
--- a/contracts/access/access_control/AccessControl.sol
+++ b/contracts/access/access_control/AccessControl.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.9;
 
 import { IAccessControl } from './IAccessControl.sol';
 import { AccessControlInternal } from './AccessControlInternal.sol';

--- a/contracts/access/access_control/AccessControl.sol
+++ b/contracts/access/access_control/AccessControl.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IAccessControl } from './IAccessControl.sol';
 import { AccessControlInternal } from './AccessControlInternal.sol';

--- a/contracts/access/access_control/AccessControlInternal.sol
+++ b/contracts/access/access_control/AccessControlInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { EnumerableSet } from '../../data/EnumerableSet.sol';
 import { AddressUtils } from '../../utils/AddressUtils.sol';

--- a/contracts/access/access_control/AccessControlInternal.sol
+++ b/contracts/access/access_control/AccessControlInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.9;
 
 import { EnumerableSet } from '../../data/EnumerableSet.sol';
 import { AddressUtils } from '../../utils/AddressUtils.sol';

--- a/contracts/access/access_control/AccessControlMock.sol
+++ b/contracts/access/access_control/AccessControlMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { AccessControl } from './AccessControl.sol';
 import { AccessControlStorage } from './AccessControlStorage.sol';

--- a/contracts/access/access_control/AccessControlMock.sol
+++ b/contracts/access/access_control/AccessControlMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.9;
 
 import { AccessControl } from './AccessControl.sol';
 import { AccessControlStorage } from './AccessControlStorage.sol';

--- a/contracts/access/access_control/AccessControlStorage.sol
+++ b/contracts/access/access_control/AccessControlStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.9;
 
 import { EnumerableSet } from '../../data/EnumerableSet.sol';
 

--- a/contracts/access/access_control/AccessControlStorage.sol
+++ b/contracts/access/access_control/AccessControlStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { EnumerableSet } from '../../data/EnumerableSet.sol';
 

--- a/contracts/access/access_control/IAccessControl.sol
+++ b/contracts/access/access_control/IAccessControl.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IAccessControlInternal } from './IAccessControlInternal.sol';
 

--- a/contracts/access/access_control/IAccessControl.sol
+++ b/contracts/access/access_control/IAccessControl.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.9;
 
 import { IAccessControlInternal } from './IAccessControlInternal.sol';
 

--- a/contracts/access/access_control/IAccessControlInternal.sol
+++ b/contracts/access/access_control/IAccessControlInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.9;
 
 /**
  * @title Partial AccessControl interface needed by internal functions

--- a/contracts/access/access_control/IAccessControlInternal.sol
+++ b/contracts/access/access_control/IAccessControlInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 /**
  * @title Partial AccessControl interface needed by internal functions

--- a/contracts/access/ownable/IOwnable.sol
+++ b/contracts/access/ownable/IOwnable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC173 } from '../../interfaces/IERC173.sol';
 import { IOwnableInternal } from './IOwnableInternal.sol';

--- a/contracts/access/ownable/IOwnable.sol
+++ b/contracts/access/ownable/IOwnable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC173 } from '../../interfaces/IERC173.sol';
 import { IOwnableInternal } from './IOwnableInternal.sol';

--- a/contracts/access/ownable/IOwnableInternal.sol
+++ b/contracts/access/ownable/IOwnableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC173Internal } from '../../interfaces/IERC173Internal.sol';
 

--- a/contracts/access/ownable/IOwnableInternal.sol
+++ b/contracts/access/ownable/IOwnableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC173Internal } from '../../interfaces/IERC173Internal.sol';
 

--- a/contracts/access/ownable/ISafeOwnable.sol
+++ b/contracts/access/ownable/ISafeOwnable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IOwnable } from './IOwnable.sol';
 import { ISafeOwnableInternal } from './ISafeOwnableInternal.sol';

--- a/contracts/access/ownable/ISafeOwnable.sol
+++ b/contracts/access/ownable/ISafeOwnable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IOwnable } from './IOwnable.sol';
 import { ISafeOwnableInternal } from './ISafeOwnableInternal.sol';

--- a/contracts/access/ownable/ISafeOwnableInternal.sol
+++ b/contracts/access/ownable/ISafeOwnableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IOwnableInternal } from './IOwnableInternal.sol';
 

--- a/contracts/access/ownable/ISafeOwnableInternal.sol
+++ b/contracts/access/ownable/ISafeOwnableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IOwnableInternal } from './IOwnableInternal.sol';
 

--- a/contracts/access/ownable/Ownable.sol
+++ b/contracts/access/ownable/Ownable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC173 } from '../../interfaces/IERC173.sol';
 import { IOwnable } from './IOwnable.sol';

--- a/contracts/access/ownable/Ownable.sol
+++ b/contracts/access/ownable/Ownable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC173 } from '../../interfaces/IERC173.sol';
 import { IOwnable } from './IOwnable.sol';

--- a/contracts/access/ownable/OwnableInternal.sol
+++ b/contracts/access/ownable/OwnableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC173 } from '../../interfaces/IERC173.sol';
 import { AddressUtils } from '../../utils/AddressUtils.sol';

--- a/contracts/access/ownable/OwnableInternal.sol
+++ b/contracts/access/ownable/OwnableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC173 } from '../../interfaces/IERC173.sol';
 import { AddressUtils } from '../../utils/AddressUtils.sol';

--- a/contracts/access/ownable/OwnableMock.sol
+++ b/contracts/access/ownable/OwnableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { Ownable } from './Ownable.sol';
 

--- a/contracts/access/ownable/OwnableMock.sol
+++ b/contracts/access/ownable/OwnableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { Ownable } from './Ownable.sol';
 

--- a/contracts/access/ownable/OwnableStorage.sol
+++ b/contracts/access/ownable/OwnableStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 library OwnableStorage {
     struct Layout {

--- a/contracts/access/ownable/OwnableStorage.sol
+++ b/contracts/access/ownable/OwnableStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 library OwnableStorage {
     struct Layout {

--- a/contracts/access/ownable/SafeOwnable.sol
+++ b/contracts/access/ownable/SafeOwnable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { Ownable } from './Ownable.sol';
 import { ISafeOwnable } from './ISafeOwnable.sol';

--- a/contracts/access/ownable/SafeOwnable.sol
+++ b/contracts/access/ownable/SafeOwnable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { Ownable } from './Ownable.sol';
 import { ISafeOwnable } from './ISafeOwnable.sol';

--- a/contracts/access/ownable/SafeOwnableInternal.sol
+++ b/contracts/access/ownable/SafeOwnableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ISafeOwnableInternal } from './ISafeOwnableInternal.sol';
 import { OwnableInternal } from './OwnableInternal.sol';

--- a/contracts/access/ownable/SafeOwnableInternal.sol
+++ b/contracts/access/ownable/SafeOwnableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ISafeOwnableInternal } from './ISafeOwnableInternal.sol';
 import { OwnableInternal } from './OwnableInternal.sol';

--- a/contracts/access/ownable/SafeOwnableMock.sol
+++ b/contracts/access/ownable/SafeOwnableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { SafeOwnable } from './SafeOwnable.sol';
 

--- a/contracts/access/ownable/SafeOwnableMock.sol
+++ b/contracts/access/ownable/SafeOwnableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { SafeOwnable } from './SafeOwnable.sol';
 

--- a/contracts/access/ownable/SafeOwnableStorage.sol
+++ b/contracts/access/ownable/SafeOwnableStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 library SafeOwnableStorage {
     struct Layout {

--- a/contracts/access/ownable/SafeOwnableStorage.sol
+++ b/contracts/access/ownable/SafeOwnableStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 library SafeOwnableStorage {
     struct Layout {

--- a/contracts/cryptography/ECDSA.sol
+++ b/contracts/cryptography/ECDSA.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 /**
  * @title Elliptic Curve Digital Signature Algorithm (ECDSA) operations

--- a/contracts/cryptography/ECDSA.sol
+++ b/contracts/cryptography/ECDSA.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 /**
  * @title Elliptic Curve Digital Signature Algorithm (ECDSA) operations

--- a/contracts/cryptography/ECDSAMock.sol
+++ b/contracts/cryptography/ECDSAMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ECDSA } from './ECDSA.sol';
 

--- a/contracts/cryptography/ECDSAMock.sol
+++ b/contracts/cryptography/ECDSAMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ECDSA } from './ECDSA.sol';
 

--- a/contracts/cryptography/EIP712.sol
+++ b/contracts/cryptography/EIP712.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 /**
  * @title EIP-712 typed structured data hashing and signing

--- a/contracts/cryptography/EIP712.sol
+++ b/contracts/cryptography/EIP712.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.9;
 
 /**
  * @title EIP-712 typed structured data hashing and signing

--- a/contracts/cryptography/EIP712Mock.sol
+++ b/contracts/cryptography/EIP712Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { EIP712 } from './EIP712.sol';
 

--- a/contracts/cryptography/EIP712Mock.sol
+++ b/contracts/cryptography/EIP712Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.9;
 
 import { EIP712 } from './EIP712.sol';
 

--- a/contracts/cryptography/MerkleProof.sol
+++ b/contracts/cryptography/MerkleProof.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 /**
  * @title Merkle tree verification utility

--- a/contracts/cryptography/MerkleProof.sol
+++ b/contracts/cryptography/MerkleProof.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 /**
  * @title Merkle tree verification utility

--- a/contracts/cryptography/MerkleProofMock.sol
+++ b/contracts/cryptography/MerkleProofMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { MerkleProof } from './MerkleProof.sol';
 

--- a/contracts/cryptography/MerkleProofMock.sol
+++ b/contracts/cryptography/MerkleProofMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { MerkleProof } from './MerkleProof.sol';
 

--- a/contracts/data/BinaryHeap.sol
+++ b/contracts/data/BinaryHeap.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 /**
  * @title Binary Heap implementation

--- a/contracts/data/BinaryHeap.sol
+++ b/contracts/data/BinaryHeap.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 /**
  * @title Binary Heap implementation

--- a/contracts/data/BinaryHeapAddressMock.sol
+++ b/contracts/data/BinaryHeapAddressMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { BinaryHeap } from './BinaryHeap.sol';
 

--- a/contracts/data/BinaryHeapAddressMock.sol
+++ b/contracts/data/BinaryHeapAddressMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { BinaryHeap } from './BinaryHeap.sol';
 

--- a/contracts/data/BinaryHeapBytes32Mock.sol
+++ b/contracts/data/BinaryHeapBytes32Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { BinaryHeap } from './BinaryHeap.sol';
 

--- a/contracts/data/BinaryHeapBytes32Mock.sol
+++ b/contracts/data/BinaryHeapBytes32Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { BinaryHeap } from './BinaryHeap.sol';
 

--- a/contracts/data/BinaryHeapUintMock.sol
+++ b/contracts/data/BinaryHeapUintMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { BinaryHeap } from './BinaryHeap.sol';
 

--- a/contracts/data/BinaryHeapUintMock.sol
+++ b/contracts/data/BinaryHeapUintMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { BinaryHeap } from './BinaryHeap.sol';
 

--- a/contracts/data/DoublyLinkedList.sol
+++ b/contracts/data/DoublyLinkedList.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 /**
  * @title Doubly linked list implementation with enumeration functions

--- a/contracts/data/DoublyLinkedList.sol
+++ b/contracts/data/DoublyLinkedList.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.9;
 
 /**
  * @title Doubly linked list implementation with enumeration functions

--- a/contracts/data/DoublyLinkedListAddressMock.sol
+++ b/contracts/data/DoublyLinkedListAddressMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.9;
 
 import { DoublyLinkedList } from './DoublyLinkedList.sol';
 

--- a/contracts/data/DoublyLinkedListAddressMock.sol
+++ b/contracts/data/DoublyLinkedListAddressMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { DoublyLinkedList } from './DoublyLinkedList.sol';
 

--- a/contracts/data/DoublyLinkedListBytes32Mock.sol
+++ b/contracts/data/DoublyLinkedListBytes32Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.9;
 
 import { DoublyLinkedList } from './DoublyLinkedList.sol';
 

--- a/contracts/data/DoublyLinkedListBytes32Mock.sol
+++ b/contracts/data/DoublyLinkedListBytes32Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { DoublyLinkedList } from './DoublyLinkedList.sol';
 

--- a/contracts/data/DoublyLinkedListUint256Mock.sol
+++ b/contracts/data/DoublyLinkedListUint256Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.9;
 
 import { DoublyLinkedList } from './DoublyLinkedList.sol';
 

--- a/contracts/data/DoublyLinkedListUint256Mock.sol
+++ b/contracts/data/DoublyLinkedListUint256Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { DoublyLinkedList } from './DoublyLinkedList.sol';
 

--- a/contracts/data/EnumerableMap.sol
+++ b/contracts/data/EnumerableMap.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 /**
  * @title Map implementation with enumeration functions

--- a/contracts/data/EnumerableMap.sol
+++ b/contracts/data/EnumerableMap.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 /**
  * @title Map implementation with enumeration functions

--- a/contracts/data/EnumerableMapAddressToAddressMock.sol
+++ b/contracts/data/EnumerableMapAddressToAddressMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { EnumerableMap } from './EnumerableMap.sol';
 

--- a/contracts/data/EnumerableMapAddressToAddressMock.sol
+++ b/contracts/data/EnumerableMapAddressToAddressMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { EnumerableMap } from './EnumerableMap.sol';
 

--- a/contracts/data/EnumerableMapUintToAddressMock.sol
+++ b/contracts/data/EnumerableMapUintToAddressMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { EnumerableMap } from './EnumerableMap.sol';
 

--- a/contracts/data/EnumerableMapUintToAddressMock.sol
+++ b/contracts/data/EnumerableMapUintToAddressMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { EnumerableMap } from './EnumerableMap.sol';
 

--- a/contracts/data/EnumerableSet.sol
+++ b/contracts/data/EnumerableSet.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 /**
  * @title Set implementation with enumeration functions

--- a/contracts/data/EnumerableSet.sol
+++ b/contracts/data/EnumerableSet.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 /**
  * @title Set implementation with enumeration functions

--- a/contracts/data/EnumerableSetAddressMock.sol
+++ b/contracts/data/EnumerableSetAddressMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { EnumerableSet } from './EnumerableSet.sol';
 

--- a/contracts/data/EnumerableSetAddressMock.sol
+++ b/contracts/data/EnumerableSetAddressMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { EnumerableSet } from './EnumerableSet.sol';
 

--- a/contracts/data/EnumerableSetBytes32Mock.sol
+++ b/contracts/data/EnumerableSetBytes32Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { EnumerableSet } from './EnumerableSet.sol';
 

--- a/contracts/data/EnumerableSetBytes32Mock.sol
+++ b/contracts/data/EnumerableSetBytes32Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { EnumerableSet } from './EnumerableSet.sol';
 

--- a/contracts/data/EnumerableSetUintMock.sol
+++ b/contracts/data/EnumerableSetUintMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { EnumerableSet } from './EnumerableSet.sol';
 

--- a/contracts/data/EnumerableSetUintMock.sol
+++ b/contracts/data/EnumerableSetUintMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { EnumerableSet } from './EnumerableSet.sol';
 

--- a/contracts/data/IncrementalMerkleTree.sol
+++ b/contracts/data/IncrementalMerkleTree.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.9;
 
 library IncrementalMerkleTree {
     using IncrementalMerkleTree for Tree;

--- a/contracts/data/IncrementalMerkleTree.sol
+++ b/contracts/data/IncrementalMerkleTree.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 library IncrementalMerkleTree {
     using IncrementalMerkleTree for Tree;

--- a/contracts/data/IncrementalMerkleTreeMock.sol
+++ b/contracts/data/IncrementalMerkleTreeMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.9;
 
 import { IncrementalMerkleTree } from './IncrementalMerkleTree.sol';
 

--- a/contracts/data/IncrementalMerkleTreeMock.sol
+++ b/contracts/data/IncrementalMerkleTreeMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IncrementalMerkleTree } from './IncrementalMerkleTree.sol';
 

--- a/contracts/factory/CloneFactory.sol
+++ b/contracts/factory/CloneFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { Factory } from './Factory.sol';
 

--- a/contracts/factory/CloneFactory.sol
+++ b/contracts/factory/CloneFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { Factory } from './Factory.sol';
 

--- a/contracts/factory/CloneFactoryMock.sol
+++ b/contracts/factory/CloneFactoryMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { CloneFactory } from './CloneFactory.sol';
 

--- a/contracts/factory/CloneFactoryMock.sol
+++ b/contracts/factory/CloneFactoryMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { CloneFactory } from './CloneFactory.sol';
 

--- a/contracts/factory/Factory.sol
+++ b/contracts/factory/Factory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 /**
  * @title Factory for arbitrary code deployment using the "CREATE" and "CREATE2" opcodes

--- a/contracts/factory/Factory.sol
+++ b/contracts/factory/Factory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 /**
  * @title Factory for arbitrary code deployment using the "CREATE" and "CREATE2" opcodes

--- a/contracts/factory/FactoryMock.sol
+++ b/contracts/factory/FactoryMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { Factory } from './Factory.sol';
 

--- a/contracts/factory/FactoryMock.sol
+++ b/contracts/factory/FactoryMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { Factory } from './Factory.sol';
 

--- a/contracts/factory/MetamorphicFactory.sol
+++ b/contracts/factory/MetamorphicFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { Factory } from './Factory.sol';
 import { MetamorphicFactoryStorage } from './MetamorphicFactoryStorage.sol';

--- a/contracts/factory/MetamorphicFactory.sol
+++ b/contracts/factory/MetamorphicFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { Factory } from './Factory.sol';
 import { MetamorphicFactoryStorage } from './MetamorphicFactoryStorage.sol';

--- a/contracts/factory/MetamorphicFactoryMock.sol
+++ b/contracts/factory/MetamorphicFactoryMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { MetamorphicFactory } from './MetamorphicFactory.sol';
 

--- a/contracts/factory/MetamorphicFactoryMock.sol
+++ b/contracts/factory/MetamorphicFactoryMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { MetamorphicFactory } from './MetamorphicFactory.sol';
 

--- a/contracts/factory/MetamorphicFactoryStorage.sol
+++ b/contracts/factory/MetamorphicFactoryStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 library MetamorphicFactoryStorage {
     struct Layout {

--- a/contracts/factory/MetamorphicFactoryStorage.sol
+++ b/contracts/factory/MetamorphicFactoryStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 library MetamorphicFactoryStorage {
     struct Layout {

--- a/contracts/factory/MinimalProxyFactory.sol
+++ b/contracts/factory/MinimalProxyFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { Factory } from './Factory.sol';
 

--- a/contracts/factory/MinimalProxyFactory.sol
+++ b/contracts/factory/MinimalProxyFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { Factory } from './Factory.sol';
 

--- a/contracts/factory/MinimalProxyFactoryMock.sol
+++ b/contracts/factory/MinimalProxyFactoryMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { MinimalProxyFactory } from './MinimalProxyFactory.sol';
 

--- a/contracts/factory/MinimalProxyFactoryMock.sol
+++ b/contracts/factory/MinimalProxyFactoryMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { MinimalProxyFactory } from './MinimalProxyFactory.sol';
 

--- a/contracts/interfaces/IERC1155.sol
+++ b/contracts/interfaces/IERC1155.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC165 } from './IERC165.sol';
 import { IERC1155Internal } from './IERC1155Internal.sol';

--- a/contracts/interfaces/IERC1155.sol
+++ b/contracts/interfaces/IERC1155.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC165 } from './IERC165.sol';
 import { IERC1155Internal } from './IERC1155Internal.sol';

--- a/contracts/interfaces/IERC1155Internal.sol
+++ b/contracts/interfaces/IERC1155Internal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 /**
  * @title Partial ERC1155 interface needed by internal functions

--- a/contracts/interfaces/IERC1155Internal.sol
+++ b/contracts/interfaces/IERC1155Internal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 /**
  * @title Partial ERC1155 interface needed by internal functions

--- a/contracts/interfaces/IERC1155Receiver.sol
+++ b/contracts/interfaces/IERC1155Receiver.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC165 } from './IERC165.sol';
 

--- a/contracts/interfaces/IERC1155Receiver.sol
+++ b/contracts/interfaces/IERC1155Receiver.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC165 } from './IERC165.sol';
 

--- a/contracts/interfaces/IERC1271.sol
+++ b/contracts/interfaces/IERC1271.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 interface IERC1271 {
     /**

--- a/contracts/interfaces/IERC1271.sol
+++ b/contracts/interfaces/IERC1271.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 interface IERC1271 {
     /**

--- a/contracts/interfaces/IERC1404.sol
+++ b/contracts/interfaces/IERC1404.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC20 } from './IERC20.sol';
 import { IERC1404Internal } from './IERC1404Internal.sol';

--- a/contracts/interfaces/IERC1404.sol
+++ b/contracts/interfaces/IERC1404.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC20 } from './IERC20.sol';
 import { IERC1404Internal } from './IERC1404Internal.sol';

--- a/contracts/interfaces/IERC1404Internal.sol
+++ b/contracts/interfaces/IERC1404Internal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC20Internal } from './IERC20Internal.sol';
 

--- a/contracts/interfaces/IERC1404Internal.sol
+++ b/contracts/interfaces/IERC1404Internal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC20Internal } from './IERC20Internal.sol';
 

--- a/contracts/interfaces/IERC165.sol
+++ b/contracts/interfaces/IERC165.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC165Internal } from './IERC165Internal.sol';
 

--- a/contracts/interfaces/IERC165.sol
+++ b/contracts/interfaces/IERC165.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC165Internal } from './IERC165Internal.sol';
 

--- a/contracts/interfaces/IERC165Internal.sol
+++ b/contracts/interfaces/IERC165Internal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 /**
  * @title ERC165 interface registration interface

--- a/contracts/interfaces/IERC165Internal.sol
+++ b/contracts/interfaces/IERC165Internal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 /**
  * @title ERC165 interface registration interface

--- a/contracts/interfaces/IERC173.sol
+++ b/contracts/interfaces/IERC173.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC173Internal } from './IERC173Internal.sol';
 

--- a/contracts/interfaces/IERC173.sol
+++ b/contracts/interfaces/IERC173.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC173Internal } from './IERC173Internal.sol';
 

--- a/contracts/interfaces/IERC173Internal.sol
+++ b/contracts/interfaces/IERC173Internal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 /**
  * @title Partial ERC173 interface needed by internal functions

--- a/contracts/interfaces/IERC173Internal.sol
+++ b/contracts/interfaces/IERC173Internal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 /**
  * @title Partial ERC173 interface needed by internal functions

--- a/contracts/interfaces/IERC20.sol
+++ b/contracts/interfaces/IERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC20Internal } from './IERC20Internal.sol';
 

--- a/contracts/interfaces/IERC20.sol
+++ b/contracts/interfaces/IERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC20Internal } from './IERC20Internal.sol';
 

--- a/contracts/interfaces/IERC20Internal.sol
+++ b/contracts/interfaces/IERC20Internal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 /**
  * @title Partial ERC20 interface needed by internal functions

--- a/contracts/interfaces/IERC20Internal.sol
+++ b/contracts/interfaces/IERC20Internal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 /**
  * @title Partial ERC20 interface needed by internal functions

--- a/contracts/interfaces/IERC2981.sol
+++ b/contracts/interfaces/IERC2981.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC165 } from './IERC165.sol';
 import { IERC2981Internal } from './IERC2981Internal.sol';

--- a/contracts/interfaces/IERC2981.sol
+++ b/contracts/interfaces/IERC2981.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC165 } from './IERC165.sol';
 import { IERC2981Internal } from './IERC2981Internal.sol';

--- a/contracts/interfaces/IERC2981Internal.sol
+++ b/contracts/interfaces/IERC2981Internal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 /**
  * @title ERC2981 interface

--- a/contracts/interfaces/IERC2981Internal.sol
+++ b/contracts/interfaces/IERC2981Internal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 /**
  * @title ERC2981 interface

--- a/contracts/interfaces/IERC3156FlashBorrower.sol
+++ b/contracts/interfaces/IERC3156FlashBorrower.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 interface IERC3156FlashBorrower {
     /**

--- a/contracts/interfaces/IERC3156FlashBorrower.sol
+++ b/contracts/interfaces/IERC3156FlashBorrower.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 interface IERC3156FlashBorrower {
     /**

--- a/contracts/interfaces/IERC3156FlashLender.sol
+++ b/contracts/interfaces/IERC3156FlashLender.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import './IERC3156FlashBorrower.sol';
 

--- a/contracts/interfaces/IERC3156FlashLender.sol
+++ b/contracts/interfaces/IERC3156FlashLender.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import './IERC3156FlashBorrower.sol';
 

--- a/contracts/interfaces/IERC4626.sol
+++ b/contracts/interfaces/IERC4626.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC20Metadata } from '../token/ERC20/metadata/IERC20Metadata.sol';
 import { IERC20 } from './IERC20.sol';

--- a/contracts/interfaces/IERC4626.sol
+++ b/contracts/interfaces/IERC4626.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC20Metadata } from '../token/ERC20/metadata/IERC20Metadata.sol';
 import { IERC20 } from './IERC20.sol';

--- a/contracts/interfaces/IERC4626Internal.sol
+++ b/contracts/interfaces/IERC4626Internal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 /**
  * @title Partial ERC4626 interface needed by internal functions

--- a/contracts/interfaces/IERC4626Internal.sol
+++ b/contracts/interfaces/IERC4626Internal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 /**
  * @title Partial ERC4626 interface needed by internal functions

--- a/contracts/interfaces/IERC721.sol
+++ b/contracts/interfaces/IERC721.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC165 } from './IERC165.sol';
 import { IERC721Internal } from './IERC721Internal.sol';

--- a/contracts/interfaces/IERC721.sol
+++ b/contracts/interfaces/IERC721.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC165 } from './IERC165.sol';
 import { IERC721Internal } from './IERC721Internal.sol';

--- a/contracts/interfaces/IERC721Internal.sol
+++ b/contracts/interfaces/IERC721Internal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 /**
  * @title Partial ERC721 interface needed by internal functions

--- a/contracts/interfaces/IERC721Internal.sol
+++ b/contracts/interfaces/IERC721Internal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 /**
  * @title Partial ERC721 interface needed by internal functions

--- a/contracts/interfaces/IERC721Receiver.sol
+++ b/contracts/interfaces/IERC721Receiver.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 interface IERC721Receiver {
     function onERC721Received(

--- a/contracts/interfaces/IERC721Receiver.sol
+++ b/contracts/interfaces/IERC721Receiver.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 interface IERC721Receiver {
     function onERC721Received(

--- a/contracts/interfaces/IWETH.sol
+++ b/contracts/interfaces/IWETH.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC20Metadata } from '../token/ERC20/metadata/IERC20Metadata.sol';
 import { IERC20 } from './IERC20.sol';

--- a/contracts/interfaces/IWETH.sol
+++ b/contracts/interfaces/IWETH.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC20Metadata } from '../token/ERC20/metadata/IERC20Metadata.sol';
 import { IERC20 } from './IERC20.sol';

--- a/contracts/introspection/ERC165/base/ERC165Base.sol
+++ b/contracts/introspection/ERC165/base/ERC165Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC165 } from '../../../interfaces/IERC165.sol';
 import { IERC165Base } from './IERC165Base.sol';

--- a/contracts/introspection/ERC165/base/ERC165Base.sol
+++ b/contracts/introspection/ERC165/base/ERC165Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC165 } from '../../../interfaces/IERC165.sol';
 import { IERC165Base } from './IERC165Base.sol';

--- a/contracts/introspection/ERC165/base/ERC165BaseInternal.sol
+++ b/contracts/introspection/ERC165/base/ERC165BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC165BaseInternal } from './IERC165BaseInternal.sol';
 import { ERC165BaseStorage } from './ERC165BaseStorage.sol';

--- a/contracts/introspection/ERC165/base/ERC165BaseInternal.sol
+++ b/contracts/introspection/ERC165/base/ERC165BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC165BaseInternal } from './IERC165BaseInternal.sol';
 import { ERC165BaseStorage } from './ERC165BaseStorage.sol';

--- a/contracts/introspection/ERC165/base/ERC165BaseMock.sol
+++ b/contracts/introspection/ERC165/base/ERC165BaseMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC165 } from '../../../interfaces/IERC165.sol';
 import { ERC165Base, ERC165BaseStorage, IERC165Base } from './ERC165Base.sol';

--- a/contracts/introspection/ERC165/base/ERC165BaseMock.sol
+++ b/contracts/introspection/ERC165/base/ERC165BaseMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC165 } from '../../../interfaces/IERC165.sol';
 import { ERC165Base, ERC165BaseStorage, IERC165Base } from './ERC165Base.sol';

--- a/contracts/introspection/ERC165/base/ERC165BaseStorage.sol
+++ b/contracts/introspection/ERC165/base/ERC165BaseStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 library ERC165BaseStorage {
     struct Layout {

--- a/contracts/introspection/ERC165/base/ERC165BaseStorage.sol
+++ b/contracts/introspection/ERC165/base/ERC165BaseStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 library ERC165BaseStorage {
     struct Layout {

--- a/contracts/introspection/ERC165/base/IERC165Base.sol
+++ b/contracts/introspection/ERC165/base/IERC165Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.9;
 
 import { IERC165 } from '../../../interfaces/IERC165.sol';
 import { IERC165BaseInternal } from './IERC165BaseInternal.sol';

--- a/contracts/introspection/ERC165/base/IERC165Base.sol
+++ b/contracts/introspection/ERC165/base/IERC165Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC165 } from '../../../interfaces/IERC165.sol';
 import { IERC165BaseInternal } from './IERC165BaseInternal.sol';

--- a/contracts/introspection/ERC165/base/IERC165BaseInternal.sol
+++ b/contracts/introspection/ERC165/base/IERC165BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.9;
 
 import { IERC165Internal } from '../../../interfaces/IERC165Internal.sol';
 

--- a/contracts/introspection/ERC165/base/IERC165BaseInternal.sol
+++ b/contracts/introspection/ERC165/base/IERC165BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC165Internal } from '../../../interfaces/IERC165Internal.sol';
 

--- a/contracts/multisig/ECDSAMultisigWallet.sol
+++ b/contracts/multisig/ECDSAMultisigWallet.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IECDSAMultisigWallet } from './IECDSAMultisigWallet.sol';
 import { ECDSAMultisigWalletInternal } from './ECDSAMultisigWalletInternal.sol';

--- a/contracts/multisig/ECDSAMultisigWallet.sol
+++ b/contracts/multisig/ECDSAMultisigWallet.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IECDSAMultisigWallet } from './IECDSAMultisigWallet.sol';
 import { ECDSAMultisigWalletInternal } from './ECDSAMultisigWalletInternal.sol';

--- a/contracts/multisig/ECDSAMultisigWalletInternal.sol
+++ b/contracts/multisig/ECDSAMultisigWalletInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ECDSA } from '../cryptography/ECDSA.sol';
 import { EnumerableSet } from '../data/EnumerableSet.sol';

--- a/contracts/multisig/ECDSAMultisigWalletInternal.sol
+++ b/contracts/multisig/ECDSAMultisigWalletInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ECDSA } from '../cryptography/ECDSA.sol';
 import { EnumerableSet } from '../data/EnumerableSet.sol';

--- a/contracts/multisig/ECDSAMultisigWalletMock.sol
+++ b/contracts/multisig/ECDSAMultisigWalletMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ECDSAMultisigWallet } from './ECDSAMultisigWallet.sol';
 

--- a/contracts/multisig/ECDSAMultisigWalletMock.sol
+++ b/contracts/multisig/ECDSAMultisigWalletMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ECDSAMultisigWallet } from './ECDSAMultisigWallet.sol';
 

--- a/contracts/multisig/ECDSAMultisigWalletStorage.sol
+++ b/contracts/multisig/ECDSAMultisigWalletStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { EnumerableSet } from '../data/EnumerableSet.sol';
 

--- a/contracts/multisig/ECDSAMultisigWalletStorage.sol
+++ b/contracts/multisig/ECDSAMultisigWalletStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { EnumerableSet } from '../data/EnumerableSet.sol';
 

--- a/contracts/multisig/IECDSAMultisigWallet.sol
+++ b/contracts/multisig/IECDSAMultisigWallet.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IECDSAMultisigWalletInternal } from './IECDSAMultisigWalletInternal.sol';
 

--- a/contracts/multisig/IECDSAMultisigWallet.sol
+++ b/contracts/multisig/IECDSAMultisigWallet.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IECDSAMultisigWalletInternal } from './IECDSAMultisigWalletInternal.sol';
 

--- a/contracts/multisig/IECDSAMultisigWalletInternal.sol
+++ b/contracts/multisig/IECDSAMultisigWalletInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 interface IECDSAMultisigWalletInternal {
     error ECDSAMultisigWallet__MessageValueMismatch();

--- a/contracts/multisig/IECDSAMultisigWalletInternal.sol
+++ b/contracts/multisig/IECDSAMultisigWalletInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 interface IECDSAMultisigWalletInternal {
     error ECDSAMultisigWallet__MessageValueMismatch();

--- a/contracts/proxy/IProxy.sol
+++ b/contracts/proxy/IProxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 interface IProxy {
     error Proxy__ImplementationIsNotContract();

--- a/contracts/proxy/IProxy.sol
+++ b/contracts/proxy/IProxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 interface IProxy {
     error Proxy__ImplementationIsNotContract();

--- a/contracts/proxy/Proxy.sol
+++ b/contracts/proxy/Proxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { AddressUtils } from '../utils/AddressUtils.sol';
 import { IProxy } from './IProxy.sol';

--- a/contracts/proxy/Proxy.sol
+++ b/contracts/proxy/Proxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { AddressUtils } from '../utils/AddressUtils.sol';
 import { IProxy } from './IProxy.sol';

--- a/contracts/proxy/ProxyMock.sol
+++ b/contracts/proxy/ProxyMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { Proxy } from './Proxy.sol';
 

--- a/contracts/proxy/ProxyMock.sol
+++ b/contracts/proxy/ProxyMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { Proxy } from './Proxy.sol';
 

--- a/contracts/proxy/diamond/ISolidStateDiamond.sol
+++ b/contracts/proxy/diamond/ISolidStateDiamond.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ISafeOwnable } from '../../access/ownable/ISafeOwnable.sol';
 import { IERC165 } from '../../interfaces/IERC165.sol';

--- a/contracts/proxy/diamond/ISolidStateDiamond.sol
+++ b/contracts/proxy/diamond/ISolidStateDiamond.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ISafeOwnable } from '../../access/ownable/ISafeOwnable.sol';
 import { IERC165 } from '../../interfaces/IERC165.sol';

--- a/contracts/proxy/diamond/SolidStateDiamond.sol
+++ b/contracts/proxy/diamond/SolidStateDiamond.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IOwnable, Ownable, OwnableInternal } from '../../access/ownable/Ownable.sol';
 import { ISafeOwnable, SafeOwnable } from '../../access/ownable/SafeOwnable.sol';

--- a/contracts/proxy/diamond/SolidStateDiamond.sol
+++ b/contracts/proxy/diamond/SolidStateDiamond.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IOwnable, Ownable, OwnableInternal } from '../../access/ownable/Ownable.sol';
 import { ISafeOwnable, SafeOwnable } from '../../access/ownable/SafeOwnable.sol';

--- a/contracts/proxy/diamond/SolidStateDiamondMock.sol
+++ b/contracts/proxy/diamond/SolidStateDiamondMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { SolidStateDiamond } from './SolidStateDiamond.sol';
 

--- a/contracts/proxy/diamond/SolidStateDiamondMock.sol
+++ b/contracts/proxy/diamond/SolidStateDiamondMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { SolidStateDiamond } from './SolidStateDiamond.sol';
 

--- a/contracts/proxy/diamond/base/DiamondBase.sol
+++ b/contracts/proxy/diamond/base/DiamondBase.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { Proxy } from '../../Proxy.sol';
 import { IDiamondBase } from './IDiamondBase.sol';

--- a/contracts/proxy/diamond/base/DiamondBase.sol
+++ b/contracts/proxy/diamond/base/DiamondBase.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { Proxy } from '../../Proxy.sol';
 import { IDiamondBase } from './IDiamondBase.sol';

--- a/contracts/proxy/diamond/base/DiamondBaseMock.sol
+++ b/contracts/proxy/diamond/base/DiamondBaseMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { DiamondWritableInternal } from '../writable/DiamondWritableInternal.sol';
 import { DiamondBase } from './DiamondBase.sol';

--- a/contracts/proxy/diamond/base/DiamondBaseMock.sol
+++ b/contracts/proxy/diamond/base/DiamondBaseMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { DiamondWritableInternal } from '../writable/DiamondWritableInternal.sol';
 import { DiamondBase } from './DiamondBase.sol';

--- a/contracts/proxy/diamond/base/DiamondBaseStorage.sol
+++ b/contracts/proxy/diamond/base/DiamondBaseStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 /**
  * @dev derived from https://github.com/mudgen/diamond-2 (MIT license)

--- a/contracts/proxy/diamond/base/DiamondBaseStorage.sol
+++ b/contracts/proxy/diamond/base/DiamondBaseStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 /**
  * @dev derived from https://github.com/mudgen/diamond-2 (MIT license)

--- a/contracts/proxy/diamond/base/IDiamondBase.sol
+++ b/contracts/proxy/diamond/base/IDiamondBase.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IProxy } from '../../IProxy.sol';
 

--- a/contracts/proxy/diamond/base/IDiamondBase.sol
+++ b/contracts/proxy/diamond/base/IDiamondBase.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IProxy } from '../../IProxy.sol';
 

--- a/contracts/proxy/diamond/fallback/DiamondFallback.sol
+++ b/contracts/proxy/diamond/fallback/DiamondFallback.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { OwnableInternal } from '../../../access/ownable/OwnableInternal.sol';
 import { DiamondBase } from '../base/DiamondBase.sol';

--- a/contracts/proxy/diamond/fallback/DiamondFallback.sol
+++ b/contracts/proxy/diamond/fallback/DiamondFallback.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { OwnableInternal } from '../../../access/ownable/OwnableInternal.sol';
 import { DiamondBase } from '../base/DiamondBase.sol';

--- a/contracts/proxy/diamond/fallback/DiamondFallbackMock.sol
+++ b/contracts/proxy/diamond/fallback/DiamondFallbackMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { DiamondWritableInternal } from '../writable/DiamondWritableInternal.sol';
 import { DiamondFallback } from './DiamondFallback.sol';

--- a/contracts/proxy/diamond/fallback/DiamondFallbackMock.sol
+++ b/contracts/proxy/diamond/fallback/DiamondFallbackMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { DiamondWritableInternal } from '../writable/DiamondWritableInternal.sol';
 import { DiamondFallback } from './DiamondFallback.sol';

--- a/contracts/proxy/diamond/fallback/IDiamondFallback.sol
+++ b/contracts/proxy/diamond/fallback/IDiamondFallback.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IDiamondBase } from '../base/IDiamondBase.sol';
 

--- a/contracts/proxy/diamond/fallback/IDiamondFallback.sol
+++ b/contracts/proxy/diamond/fallback/IDiamondFallback.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IDiamondBase } from '../base/IDiamondBase.sol';
 

--- a/contracts/proxy/diamond/readable/DiamondReadable.sol
+++ b/contracts/proxy/diamond/readable/DiamondReadable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { DiamondBaseStorage } from '../base/DiamondBaseStorage.sol';
 import { IDiamondReadable } from './IDiamondReadable.sol';

--- a/contracts/proxy/diamond/readable/DiamondReadable.sol
+++ b/contracts/proxy/diamond/readable/DiamondReadable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { DiamondBaseStorage } from '../base/DiamondBaseStorage.sol';
 import { IDiamondReadable } from './IDiamondReadable.sol';

--- a/contracts/proxy/diamond/readable/DiamondReadableMock.sol
+++ b/contracts/proxy/diamond/readable/DiamondReadableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC165 } from '../../../interfaces/IERC165.sol';
 import { ERC165Base } from '../../../introspection/ERC165/base/ERC165Base.sol';

--- a/contracts/proxy/diamond/readable/DiamondReadableMock.sol
+++ b/contracts/proxy/diamond/readable/DiamondReadableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC165 } from '../../../interfaces/IERC165.sol';
 import { ERC165Base } from '../../../introspection/ERC165/base/ERC165Base.sol';

--- a/contracts/proxy/diamond/readable/IDiamondReadable.sol
+++ b/contracts/proxy/diamond/readable/IDiamondReadable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 /**
  * @title Diamond proxy introspection interface

--- a/contracts/proxy/diamond/readable/IDiamondReadable.sol
+++ b/contracts/proxy/diamond/readable/IDiamondReadable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 /**
  * @title Diamond proxy introspection interface

--- a/contracts/proxy/diamond/writable/DiamondWritable.sol
+++ b/contracts/proxy/diamond/writable/DiamondWritable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { OwnableInternal } from '../../../access/ownable/OwnableInternal.sol';
 import { IDiamondWritable } from './IDiamondWritable.sol';

--- a/contracts/proxy/diamond/writable/DiamondWritable.sol
+++ b/contracts/proxy/diamond/writable/DiamondWritable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { OwnableInternal } from '../../../access/ownable/OwnableInternal.sol';
 import { IDiamondWritable } from './IDiamondWritable.sol';

--- a/contracts/proxy/diamond/writable/DiamondWritableInternal.sol
+++ b/contracts/proxy/diamond/writable/DiamondWritableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { AddressUtils } from '../../../utils/AddressUtils.sol';
 import { DiamondBaseStorage } from '../base/DiamondBaseStorage.sol';

--- a/contracts/proxy/diamond/writable/DiamondWritableInternal.sol
+++ b/contracts/proxy/diamond/writable/DiamondWritableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.9;
 
 import { AddressUtils } from '../../../utils/AddressUtils.sol';
 import { DiamondBaseStorage } from '../base/DiamondBaseStorage.sol';

--- a/contracts/proxy/diamond/writable/DiamondWritableMock.sol
+++ b/contracts/proxy/diamond/writable/DiamondWritableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC165 } from '../../../interfaces/IERC165.sol';
 import { ERC165Base, ERC165BaseStorage } from '../../../introspection/ERC165/base/ERC165Base.sol';

--- a/contracts/proxy/diamond/writable/DiamondWritableMock.sol
+++ b/contracts/proxy/diamond/writable/DiamondWritableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC165 } from '../../../interfaces/IERC165.sol';
 import { ERC165Base, ERC165BaseStorage } from '../../../introspection/ERC165/base/ERC165Base.sol';

--- a/contracts/proxy/diamond/writable/IDiamondWritable.sol
+++ b/contracts/proxy/diamond/writable/IDiamondWritable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IDiamondWritableInternal } from './IDiamondWritableInternal.sol';
 

--- a/contracts/proxy/diamond/writable/IDiamondWritable.sol
+++ b/contracts/proxy/diamond/writable/IDiamondWritable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IDiamondWritableInternal } from './IDiamondWritableInternal.sol';
 

--- a/contracts/proxy/diamond/writable/IDiamondWritableInternal.sol
+++ b/contracts/proxy/diamond/writable/IDiamondWritableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 interface IDiamondWritableInternal {
     enum FacetCutAction {

--- a/contracts/proxy/diamond/writable/IDiamondWritableInternal.sol
+++ b/contracts/proxy/diamond/writable/IDiamondWritableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 interface IDiamondWritableInternal {
     enum FacetCutAction {

--- a/contracts/proxy/managed/IManagedProxy.sol
+++ b/contracts/proxy/managed/IManagedProxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IProxy } from '../IProxy.sol';
 

--- a/contracts/proxy/managed/IManagedProxy.sol
+++ b/contracts/proxy/managed/IManagedProxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IProxy } from '../IProxy.sol';
 

--- a/contracts/proxy/managed/IManagedProxyOwnable.sol
+++ b/contracts/proxy/managed/IManagedProxyOwnable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IManagedProxy } from './IManagedProxy.sol';
 

--- a/contracts/proxy/managed/IManagedProxyOwnable.sol
+++ b/contracts/proxy/managed/IManagedProxyOwnable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IManagedProxy } from './IManagedProxy.sol';
 

--- a/contracts/proxy/managed/ManagedProxy.sol
+++ b/contracts/proxy/managed/ManagedProxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { Proxy } from '../Proxy.sol';
 import { IManagedProxy } from './IManagedProxy.sol';

--- a/contracts/proxy/managed/ManagedProxy.sol
+++ b/contracts/proxy/managed/ManagedProxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { Proxy } from '../Proxy.sol';
 import { IManagedProxy } from './IManagedProxy.sol';

--- a/contracts/proxy/managed/ManagedProxyMock.sol
+++ b/contracts/proxy/managed/ManagedProxyMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ManagedProxy } from './ManagedProxy.sol';
 

--- a/contracts/proxy/managed/ManagedProxyMock.sol
+++ b/contracts/proxy/managed/ManagedProxyMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ManagedProxy } from './ManagedProxy.sol';
 

--- a/contracts/proxy/managed/ManagedProxyOwnable.sol
+++ b/contracts/proxy/managed/ManagedProxyOwnable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { OwnableInternal } from '../../access/ownable/OwnableInternal.sol';
 import { IManagedProxyOwnable } from './IManagedProxyOwnable.sol';

--- a/contracts/proxy/managed/ManagedProxyOwnable.sol
+++ b/contracts/proxy/managed/ManagedProxyOwnable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { OwnableInternal } from '../../access/ownable/OwnableInternal.sol';
 import { IManagedProxyOwnable } from './IManagedProxyOwnable.sol';

--- a/contracts/proxy/managed/ManagedProxyOwnableMock.sol
+++ b/contracts/proxy/managed/ManagedProxyOwnableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ManagedProxy, ManagedProxyOwnable } from './ManagedProxyOwnable.sol';
 

--- a/contracts/proxy/managed/ManagedProxyOwnableMock.sol
+++ b/contracts/proxy/managed/ManagedProxyOwnableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ManagedProxy, ManagedProxyOwnable } from './ManagedProxyOwnable.sol';
 

--- a/contracts/proxy/upgradeable/IUpgradeableProxy.sol
+++ b/contracts/proxy/upgradeable/IUpgradeableProxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IProxy } from '../IProxy.sol';
 

--- a/contracts/proxy/upgradeable/IUpgradeableProxy.sol
+++ b/contracts/proxy/upgradeable/IUpgradeableProxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IProxy } from '../IProxy.sol';
 

--- a/contracts/proxy/upgradeable/IUpgradeableProxyOwnable.sol
+++ b/contracts/proxy/upgradeable/IUpgradeableProxyOwnable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IUpgradeableProxy } from './IUpgradeableProxy.sol';
 

--- a/contracts/proxy/upgradeable/IUpgradeableProxyOwnable.sol
+++ b/contracts/proxy/upgradeable/IUpgradeableProxyOwnable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IUpgradeableProxy } from './IUpgradeableProxy.sol';
 

--- a/contracts/proxy/upgradeable/UpgradeableProxy.sol
+++ b/contracts/proxy/upgradeable/UpgradeableProxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { Proxy } from '../Proxy.sol';
 import { IUpgradeableProxy } from './IUpgradeableProxy.sol';

--- a/contracts/proxy/upgradeable/UpgradeableProxy.sol
+++ b/contracts/proxy/upgradeable/UpgradeableProxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { Proxy } from '../Proxy.sol';
 import { IUpgradeableProxy } from './IUpgradeableProxy.sol';

--- a/contracts/proxy/upgradeable/UpgradeableProxyMock.sol
+++ b/contracts/proxy/upgradeable/UpgradeableProxyMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { UpgradeableProxy } from './UpgradeableProxy.sol';
 

--- a/contracts/proxy/upgradeable/UpgradeableProxyMock.sol
+++ b/contracts/proxy/upgradeable/UpgradeableProxyMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { UpgradeableProxy } from './UpgradeableProxy.sol';
 

--- a/contracts/proxy/upgradeable/UpgradeableProxyOwnable.sol
+++ b/contracts/proxy/upgradeable/UpgradeableProxyOwnable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { OwnableInternal } from '../../access/ownable/OwnableInternal.sol';
 import { IUpgradeableProxyOwnable } from './IUpgradeableProxyOwnable.sol';

--- a/contracts/proxy/upgradeable/UpgradeableProxyOwnable.sol
+++ b/contracts/proxy/upgradeable/UpgradeableProxyOwnable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { OwnableInternal } from '../../access/ownable/OwnableInternal.sol';
 import { IUpgradeableProxyOwnable } from './IUpgradeableProxyOwnable.sol';

--- a/contracts/proxy/upgradeable/UpgradeableProxyOwnableMock.sol
+++ b/contracts/proxy/upgradeable/UpgradeableProxyOwnableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { UpgradeableProxyOwnable } from './UpgradeableProxyOwnable.sol';
 

--- a/contracts/proxy/upgradeable/UpgradeableProxyOwnableMock.sol
+++ b/contracts/proxy/upgradeable/UpgradeableProxyOwnableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { UpgradeableProxyOwnable } from './UpgradeableProxyOwnable.sol';
 

--- a/contracts/proxy/upgradeable/UpgradeableProxyStorage.sol
+++ b/contracts/proxy/upgradeable/UpgradeableProxyStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 library UpgradeableProxyStorage {
     struct Layout {

--- a/contracts/proxy/upgradeable/UpgradeableProxyStorage.sol
+++ b/contracts/proxy/upgradeable/UpgradeableProxyStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 library UpgradeableProxyStorage {
     struct Layout {

--- a/contracts/security/initializable/IInitializable.sol
+++ b/contracts/security/initializable/IInitializable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IInitializableInternal } from './IInitializableInternal.sol';
 

--- a/contracts/security/initializable/IInitializable.sol
+++ b/contracts/security/initializable/IInitializable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IInitializableInternal } from './IInitializableInternal.sol';
 

--- a/contracts/security/initializable/IInitializableInternal.sol
+++ b/contracts/security/initializable/IInitializableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 interface IInitializableInternal {
     error Initializable__AlreadyInitialized();

--- a/contracts/security/initializable/IInitializableInternal.sol
+++ b/contracts/security/initializable/IInitializableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 interface IInitializableInternal {
     error Initializable__AlreadyInitialized();

--- a/contracts/security/initializable/Initializable.sol
+++ b/contracts/security/initializable/Initializable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IInitializable } from './IInitializable.sol';
 import { InitializableInternal } from './InitializableInternal.sol';

--- a/contracts/security/initializable/Initializable.sol
+++ b/contracts/security/initializable/Initializable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IInitializable } from './IInitializable.sol';
 import { InitializableInternal } from './InitializableInternal.sol';

--- a/contracts/security/initializable/InitializableInternal.sol
+++ b/contracts/security/initializable/InitializableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { AddressUtils } from '../../utils/AddressUtils.sol';
 import { IInitializableInternal } from './IInitializableInternal.sol';

--- a/contracts/security/initializable/InitializableInternal.sol
+++ b/contracts/security/initializable/InitializableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { AddressUtils } from '../../utils/AddressUtils.sol';
 import { IInitializableInternal } from './IInitializableInternal.sol';

--- a/contracts/security/initializable/InitializableMock.sol
+++ b/contracts/security/initializable/InitializableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { Initializable } from './Initializable.sol';
 

--- a/contracts/security/initializable/InitializableMock.sol
+++ b/contracts/security/initializable/InitializableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { Initializable } from './Initializable.sol';
 

--- a/contracts/security/initializable/InitializableStorage.sol
+++ b/contracts/security/initializable/InitializableStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 library InitializableStorage {
     struct Layout {

--- a/contracts/security/initializable/InitializableStorage.sol
+++ b/contracts/security/initializable/InitializableStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 library InitializableStorage {
     struct Layout {

--- a/contracts/security/partially_pausable/IPartiallyPausable.sol
+++ b/contracts/security/partially_pausable/IPartiallyPausable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IPartiallyPausableInternal } from './IPartiallyPausableInternal.sol';
 

--- a/contracts/security/partially_pausable/IPartiallyPausable.sol
+++ b/contracts/security/partially_pausable/IPartiallyPausable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IPartiallyPausableInternal } from './IPartiallyPausableInternal.sol';
 

--- a/contracts/security/partially_pausable/IPartiallyPausableInternal.sol
+++ b/contracts/security/partially_pausable/IPartiallyPausableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 interface IPartiallyPausableInternal {
     error PartiallyPausable__PartiallyPaused();

--- a/contracts/security/partially_pausable/IPartiallyPausableInternal.sol
+++ b/contracts/security/partially_pausable/IPartiallyPausableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 interface IPartiallyPausableInternal {
     error PartiallyPausable__PartiallyPaused();

--- a/contracts/security/partially_pausable/PartiallyPausable.sol
+++ b/contracts/security/partially_pausable/PartiallyPausable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IPartiallyPausable } from './IPartiallyPausable.sol';
 import { PartiallyPausableInternal } from './PartiallyPausableInternal.sol';

--- a/contracts/security/partially_pausable/PartiallyPausable.sol
+++ b/contracts/security/partially_pausable/PartiallyPausable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IPartiallyPausable } from './IPartiallyPausable.sol';
 import { PartiallyPausableInternal } from './PartiallyPausableInternal.sol';

--- a/contracts/security/partially_pausable/PartiallyPausableInternal.sol
+++ b/contracts/security/partially_pausable/PartiallyPausableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IPartiallyPausableInternal } from './IPartiallyPausableInternal.sol';
 import { PartiallyPausableStorage } from './PartiallyPausableStorage.sol';

--- a/contracts/security/partially_pausable/PartiallyPausableInternal.sol
+++ b/contracts/security/partially_pausable/PartiallyPausableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IPartiallyPausableInternal } from './IPartiallyPausableInternal.sol';
 import { PartiallyPausableStorage } from './PartiallyPausableStorage.sol';

--- a/contracts/security/partially_pausable/PartiallyPausableMock.sol
+++ b/contracts/security/partially_pausable/PartiallyPausableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { PartiallyPausable } from './PartiallyPausable.sol';
 

--- a/contracts/security/partially_pausable/PartiallyPausableMock.sol
+++ b/contracts/security/partially_pausable/PartiallyPausableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { PartiallyPausable } from './PartiallyPausable.sol';
 

--- a/contracts/security/partially_pausable/PartiallyPausableStorage.sol
+++ b/contracts/security/partially_pausable/PartiallyPausableStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 library PartiallyPausableStorage {
     struct Layout {

--- a/contracts/security/partially_pausable/PartiallyPausableStorage.sol
+++ b/contracts/security/partially_pausable/PartiallyPausableStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 library PartiallyPausableStorage {
     struct Layout {

--- a/contracts/security/pausable/IPausable.sol
+++ b/contracts/security/pausable/IPausable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IPausableInternal } from './IPausableInternal.sol';
 

--- a/contracts/security/pausable/IPausable.sol
+++ b/contracts/security/pausable/IPausable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IPausableInternal } from './IPausableInternal.sol';
 

--- a/contracts/security/pausable/IPausableInternal.sol
+++ b/contracts/security/pausable/IPausableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 interface IPausableInternal {
     error Pausable__Paused();

--- a/contracts/security/pausable/IPausableInternal.sol
+++ b/contracts/security/pausable/IPausableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 interface IPausableInternal {
     error Pausable__Paused();

--- a/contracts/security/pausable/Pausable.sol
+++ b/contracts/security/pausable/Pausable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IPausable } from './IPausable.sol';
 import { PausableInternal } from './PausableInternal.sol';

--- a/contracts/security/pausable/Pausable.sol
+++ b/contracts/security/pausable/Pausable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IPausable } from './IPausable.sol';
 import { PausableInternal } from './PausableInternal.sol';

--- a/contracts/security/pausable/PausableInternal.sol
+++ b/contracts/security/pausable/PausableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IPausableInternal } from './IPausableInternal.sol';
 import { PausableStorage } from './PausableStorage.sol';

--- a/contracts/security/pausable/PausableInternal.sol
+++ b/contracts/security/pausable/PausableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IPausableInternal } from './IPausableInternal.sol';
 import { PausableStorage } from './PausableStorage.sol';

--- a/contracts/security/pausable/PausableMock.sol
+++ b/contracts/security/pausable/PausableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { Pausable } from './Pausable.sol';
 

--- a/contracts/security/pausable/PausableMock.sol
+++ b/contracts/security/pausable/PausableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { Pausable } from './Pausable.sol';
 

--- a/contracts/security/pausable/PausableStorage.sol
+++ b/contracts/security/pausable/PausableStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 library PausableStorage {
     struct Layout {

--- a/contracts/security/pausable/PausableStorage.sol
+++ b/contracts/security/pausable/PausableStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 library PausableStorage {
     struct Layout {

--- a/contracts/security/reentrancy_guard/IReentrancyGuard.sol
+++ b/contracts/security/reentrancy_guard/IReentrancyGuard.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 interface IReentrancyGuard {
     error ReentrancyGuard__ReentrantCall();

--- a/contracts/security/reentrancy_guard/IReentrancyGuard.sol
+++ b/contracts/security/reentrancy_guard/IReentrancyGuard.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.9;
 
 interface IReentrancyGuard {
     error ReentrancyGuard__ReentrantCall();

--- a/contracts/security/reentrancy_guard/ReentrancyGuard.sol
+++ b/contracts/security/reentrancy_guard/ReentrancyGuard.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IReentrancyGuard } from './IReentrancyGuard.sol';
 import { ReentrancyGuardStorage } from './ReentrancyGuardStorage.sol';

--- a/contracts/security/reentrancy_guard/ReentrancyGuard.sol
+++ b/contracts/security/reentrancy_guard/ReentrancyGuard.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IReentrancyGuard } from './IReentrancyGuard.sol';
 import { ReentrancyGuardStorage } from './ReentrancyGuardStorage.sol';

--- a/contracts/security/reentrancy_guard/ReentrancyGuardMock.sol
+++ b/contracts/security/reentrancy_guard/ReentrancyGuardMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ReentrancyGuard } from './ReentrancyGuard.sol';
 

--- a/contracts/security/reentrancy_guard/ReentrancyGuardMock.sol
+++ b/contracts/security/reentrancy_guard/ReentrancyGuardMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ReentrancyGuard } from './ReentrancyGuard.sol';
 

--- a/contracts/security/reentrancy_guard/ReentrancyGuardStorage.sol
+++ b/contracts/security/reentrancy_guard/ReentrancyGuardStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 library ReentrancyGuardStorage {
     struct Layout {

--- a/contracts/security/reentrancy_guard/ReentrancyGuardStorage.sol
+++ b/contracts/security/reentrancy_guard/ReentrancyGuardStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 library ReentrancyGuardStorage {
     struct Layout {

--- a/contracts/signature/base/ERC1271Base.sol
+++ b/contracts/signature/base/ERC1271Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC1271 } from '../../interfaces/IERC1271.sol';
 import { IERC1271Base } from './IERC1271Base.sol';

--- a/contracts/signature/base/ERC1271Base.sol
+++ b/contracts/signature/base/ERC1271Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC1271 } from '../../interfaces/IERC1271.sol';
 import { IERC1271Base } from './IERC1271Base.sol';

--- a/contracts/signature/base/ERC1271BaseInternal.sol
+++ b/contracts/signature/base/ERC1271BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC1271 } from '../../interfaces/IERC1271.sol';
 

--- a/contracts/signature/base/ERC1271BaseInternal.sol
+++ b/contracts/signature/base/ERC1271BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC1271 } from '../../interfaces/IERC1271.sol';
 

--- a/contracts/signature/base/IERC1271Base.sol
+++ b/contracts/signature/base/IERC1271Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC1271 } from '../../interfaces/IERC1271.sol';
 

--- a/contracts/signature/base/IERC1271Base.sol
+++ b/contracts/signature/base/IERC1271Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC1271 } from '../../interfaces/IERC1271.sol';
 

--- a/contracts/signature/ownable/ERC1271Ownable.sol
+++ b/contracts/signature/ownable/ERC1271Ownable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC1271Base } from '../base/ERC1271Base.sol';
 import { IERC1271Ownable } from './IERC1271Ownable.sol';

--- a/contracts/signature/ownable/ERC1271Ownable.sol
+++ b/contracts/signature/ownable/ERC1271Ownable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC1271Base } from '../base/ERC1271Base.sol';
 import { IERC1271Ownable } from './IERC1271Ownable.sol';

--- a/contracts/signature/ownable/ERC1271OwnableInternal.sol
+++ b/contracts/signature/ownable/ERC1271OwnableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { OwnableInternal } from '../../access/ownable/OwnableInternal.sol';
 import { ECDSA } from '../../cryptography/ECDSA.sol';

--- a/contracts/signature/ownable/ERC1271OwnableInternal.sol
+++ b/contracts/signature/ownable/ERC1271OwnableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { OwnableInternal } from '../../access/ownable/OwnableInternal.sol';
 import { ECDSA } from '../../cryptography/ECDSA.sol';

--- a/contracts/signature/ownable/ERC1271OwnableMock.sol
+++ b/contracts/signature/ownable/ERC1271OwnableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC1271Ownable } from './ERC1271Ownable.sol';
 

--- a/contracts/signature/ownable/ERC1271OwnableMock.sol
+++ b/contracts/signature/ownable/ERC1271OwnableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC1271Ownable } from './ERC1271Ownable.sol';
 

--- a/contracts/signature/ownable/IERC1271Ownable.sol
+++ b/contracts/signature/ownable/IERC1271Ownable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC1271Base } from '../base/IERC1271Base.sol';
 

--- a/contracts/signature/ownable/IERC1271Ownable.sol
+++ b/contracts/signature/ownable/IERC1271Ownable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC1271Base } from '../base/IERC1271Base.sol';
 

--- a/contracts/signature/stored/ERC1271Stored.sol
+++ b/contracts/signature/stored/ERC1271Stored.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC1271Base } from '../base/ERC1271Base.sol';
 import { IERC1271Stored } from './IERC1271Stored.sol';

--- a/contracts/signature/stored/ERC1271Stored.sol
+++ b/contracts/signature/stored/ERC1271Stored.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC1271Base } from '../base/ERC1271Base.sol';
 import { IERC1271Stored } from './IERC1271Stored.sol';

--- a/contracts/signature/stored/ERC1271StoredInternal.sol
+++ b/contracts/signature/stored/ERC1271StoredInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC1271BaseInternal } from '../base/ERC1271BaseInternal.sol';
 import { ERC1271StoredStorage } from './ERC1271StoredStorage.sol';

--- a/contracts/signature/stored/ERC1271StoredInternal.sol
+++ b/contracts/signature/stored/ERC1271StoredInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC1271BaseInternal } from '../base/ERC1271BaseInternal.sol';
 import { ERC1271StoredStorage } from './ERC1271StoredStorage.sol';

--- a/contracts/signature/stored/ERC1271StoredMock.sol
+++ b/contracts/signature/stored/ERC1271StoredMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC1271StoredStorage } from './ERC1271StoredStorage.sol';
 import { ERC1271Stored } from './ERC1271Stored.sol';

--- a/contracts/signature/stored/ERC1271StoredMock.sol
+++ b/contracts/signature/stored/ERC1271StoredMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC1271StoredStorage } from './ERC1271StoredStorage.sol';
 import { ERC1271Stored } from './ERC1271Stored.sol';

--- a/contracts/signature/stored/ERC1271StoredStorage.sol
+++ b/contracts/signature/stored/ERC1271StoredStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 library ERC1271StoredStorage {
     struct Layout {

--- a/contracts/signature/stored/ERC1271StoredStorage.sol
+++ b/contracts/signature/stored/ERC1271StoredStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 library ERC1271StoredStorage {
     struct Layout {

--- a/contracts/signature/stored/IERC1271Stored.sol
+++ b/contracts/signature/stored/IERC1271Stored.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC1271Base } from '../base/IERC1271Base.sol';
 

--- a/contracts/signature/stored/IERC1271Stored.sol
+++ b/contracts/signature/stored/IERC1271Stored.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC1271Base } from '../base/IERC1271Base.sol';
 

--- a/contracts/token/ERC1155/ISolidStateERC1155.sol
+++ b/contracts/token/ERC1155/ISolidStateERC1155.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC1155Base } from './base/IERC1155Base.sol';
 import { IERC1155Enumerable } from './enumerable/IERC1155Enumerable.sol';

--- a/contracts/token/ERC1155/ISolidStateERC1155.sol
+++ b/contracts/token/ERC1155/ISolidStateERC1155.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC1155Base } from './base/IERC1155Base.sol';
 import { IERC1155Enumerable } from './enumerable/IERC1155Enumerable.sol';

--- a/contracts/token/ERC1155/SolidStateERC1155.sol
+++ b/contracts/token/ERC1155/SolidStateERC1155.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC165Base } from '../../introspection/ERC165/base/ERC165Base.sol';
 import { ERC1155Base, ERC1155BaseInternal } from './base/ERC1155Base.sol';

--- a/contracts/token/ERC1155/SolidStateERC1155.sol
+++ b/contracts/token/ERC1155/SolidStateERC1155.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC165Base } from '../../introspection/ERC165/base/ERC165Base.sol';
 import { ERC1155Base, ERC1155BaseInternal } from './base/ERC1155Base.sol';

--- a/contracts/token/ERC1155/SolidStateERC1155Mock.sol
+++ b/contracts/token/ERC1155/SolidStateERC1155Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC165 } from '../../interfaces/IERC165.sol';
 import { IERC1155 } from '../../interfaces/IERC1155.sol';

--- a/contracts/token/ERC1155/SolidStateERC1155Mock.sol
+++ b/contracts/token/ERC1155/SolidStateERC1155Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC165 } from '../../interfaces/IERC165.sol';
 import { IERC1155 } from '../../interfaces/IERC1155.sol';

--- a/contracts/token/ERC1155/base/ERC1155Base.sol
+++ b/contracts/token/ERC1155/base/ERC1155Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC1155 } from '../../../interfaces/IERC1155.sol';
 import { IERC1155Receiver } from '../../../interfaces/IERC1155Receiver.sol';

--- a/contracts/token/ERC1155/base/ERC1155Base.sol
+++ b/contracts/token/ERC1155/base/ERC1155Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC1155 } from '../../../interfaces/IERC1155.sol';
 import { IERC1155Receiver } from '../../../interfaces/IERC1155Receiver.sol';

--- a/contracts/token/ERC1155/base/ERC1155BaseInternal.sol
+++ b/contracts/token/ERC1155/base/ERC1155BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC1155Receiver } from '../../../interfaces/IERC1155Receiver.sol';
 import { AddressUtils } from '../../../utils/AddressUtils.sol';

--- a/contracts/token/ERC1155/base/ERC1155BaseInternal.sol
+++ b/contracts/token/ERC1155/base/ERC1155BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC1155Receiver } from '../../../interfaces/IERC1155Receiver.sol';
 import { AddressUtils } from '../../../utils/AddressUtils.sol';

--- a/contracts/token/ERC1155/base/ERC1155BaseMock.sol
+++ b/contracts/token/ERC1155/base/ERC1155BaseMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC165 } from '../../../interfaces/IERC165.sol';
 import { ERC165Base } from '../../../introspection/ERC165/base/ERC165Base.sol';

--- a/contracts/token/ERC1155/base/ERC1155BaseMock.sol
+++ b/contracts/token/ERC1155/base/ERC1155BaseMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC165 } from '../../../interfaces/IERC165.sol';
 import { ERC165Base } from '../../../introspection/ERC165/base/ERC165Base.sol';

--- a/contracts/token/ERC1155/base/ERC1155BaseStorage.sol
+++ b/contracts/token/ERC1155/base/ERC1155BaseStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 library ERC1155BaseStorage {
     struct Layout {

--- a/contracts/token/ERC1155/base/ERC1155BaseStorage.sol
+++ b/contracts/token/ERC1155/base/ERC1155BaseStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 library ERC1155BaseStorage {
     struct Layout {

--- a/contracts/token/ERC1155/base/IERC1155Base.sol
+++ b/contracts/token/ERC1155/base/IERC1155Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC1155 } from '../../../interfaces/IERC1155.sol';
 import { IERC1155BaseInternal } from './IERC1155BaseInternal.sol';

--- a/contracts/token/ERC1155/base/IERC1155Base.sol
+++ b/contracts/token/ERC1155/base/IERC1155Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC1155 } from '../../../interfaces/IERC1155.sol';
 import { IERC1155BaseInternal } from './IERC1155BaseInternal.sol';

--- a/contracts/token/ERC1155/base/IERC1155BaseInternal.sol
+++ b/contracts/token/ERC1155/base/IERC1155BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC1155Internal } from '../../../interfaces/IERC1155Internal.sol';
 

--- a/contracts/token/ERC1155/base/IERC1155BaseInternal.sol
+++ b/contracts/token/ERC1155/base/IERC1155BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC1155Internal } from '../../../interfaces/IERC1155Internal.sol';
 

--- a/contracts/token/ERC1155/enumerable/ERC1155Enumerable.sol
+++ b/contracts/token/ERC1155/enumerable/ERC1155Enumerable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { EnumerableSet } from '../../../data/EnumerableSet.sol';
 import { ERC1155BaseInternal } from '../base/ERC1155BaseInternal.sol';

--- a/contracts/token/ERC1155/enumerable/ERC1155Enumerable.sol
+++ b/contracts/token/ERC1155/enumerable/ERC1155Enumerable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { EnumerableSet } from '../../../data/EnumerableSet.sol';
 import { ERC1155BaseInternal } from '../base/ERC1155BaseInternal.sol';

--- a/contracts/token/ERC1155/enumerable/ERC1155EnumerableInternal.sol
+++ b/contracts/token/ERC1155/enumerable/ERC1155EnumerableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { EnumerableSet } from '../../../data/EnumerableSet.sol';
 import { ERC1155BaseInternal, ERC1155BaseStorage } from '../base/ERC1155BaseInternal.sol';

--- a/contracts/token/ERC1155/enumerable/ERC1155EnumerableInternal.sol
+++ b/contracts/token/ERC1155/enumerable/ERC1155EnumerableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { EnumerableSet } from '../../../data/EnumerableSet.sol';
 import { ERC1155BaseInternal, ERC1155BaseStorage } from '../base/ERC1155BaseInternal.sol';

--- a/contracts/token/ERC1155/enumerable/ERC1155EnumerableMock.sol
+++ b/contracts/token/ERC1155/enumerable/ERC1155EnumerableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC165 } from '../../../interfaces/IERC165.sol';
 import { IERC1155 } from '../../../interfaces/IERC1155.sol';

--- a/contracts/token/ERC1155/enumerable/ERC1155EnumerableMock.sol
+++ b/contracts/token/ERC1155/enumerable/ERC1155EnumerableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC165 } from '../../../interfaces/IERC165.sol';
 import { IERC1155 } from '../../../interfaces/IERC1155.sol';

--- a/contracts/token/ERC1155/enumerable/ERC1155EnumerableStorage.sol
+++ b/contracts/token/ERC1155/enumerable/ERC1155EnumerableStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { EnumerableSet } from '../../../data/EnumerableSet.sol';
 

--- a/contracts/token/ERC1155/enumerable/ERC1155EnumerableStorage.sol
+++ b/contracts/token/ERC1155/enumerable/ERC1155EnumerableStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { EnumerableSet } from '../../../data/EnumerableSet.sol';
 

--- a/contracts/token/ERC1155/enumerable/IERC1155Enumerable.sol
+++ b/contracts/token/ERC1155/enumerable/IERC1155Enumerable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC1155BaseInternal } from '../base/IERC1155BaseInternal.sol';
 

--- a/contracts/token/ERC1155/enumerable/IERC1155Enumerable.sol
+++ b/contracts/token/ERC1155/enumerable/IERC1155Enumerable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC1155BaseInternal } from '../base/IERC1155BaseInternal.sol';
 

--- a/contracts/token/ERC1155/metadata/ERC1155Metadata.sol
+++ b/contracts/token/ERC1155/metadata/ERC1155Metadata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { UintUtils } from '../../../utils/UintUtils.sol';
 import { IERC1155Metadata } from './IERC1155Metadata.sol';

--- a/contracts/token/ERC1155/metadata/ERC1155Metadata.sol
+++ b/contracts/token/ERC1155/metadata/ERC1155Metadata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { UintUtils } from '../../../utils/UintUtils.sol';
 import { IERC1155Metadata } from './IERC1155Metadata.sol';

--- a/contracts/token/ERC1155/metadata/ERC1155MetadataInternal.sol
+++ b/contracts/token/ERC1155/metadata/ERC1155MetadataInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC1155MetadataInternal } from './IERC1155MetadataInternal.sol';
 import { ERC1155MetadataStorage } from './ERC1155MetadataStorage.sol';

--- a/contracts/token/ERC1155/metadata/ERC1155MetadataInternal.sol
+++ b/contracts/token/ERC1155/metadata/ERC1155MetadataInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC1155MetadataInternal } from './IERC1155MetadataInternal.sol';
 import { ERC1155MetadataStorage } from './ERC1155MetadataStorage.sol';

--- a/contracts/token/ERC1155/metadata/ERC1155MetadataMock.sol
+++ b/contracts/token/ERC1155/metadata/ERC1155MetadataMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC1155Metadata, ERC1155MetadataStorage } from './ERC1155Metadata.sol';
 import { ERC165Base } from '../../../introspection/ERC165/base/ERC165Base.sol';

--- a/contracts/token/ERC1155/metadata/ERC1155MetadataMock.sol
+++ b/contracts/token/ERC1155/metadata/ERC1155MetadataMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC1155Metadata, ERC1155MetadataStorage } from './ERC1155Metadata.sol';
 import { ERC165Base } from '../../../introspection/ERC165/base/ERC165Base.sol';

--- a/contracts/token/ERC1155/metadata/ERC1155MetadataStorage.sol
+++ b/contracts/token/ERC1155/metadata/ERC1155MetadataStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 /**
  * @title ERC1155 metadata extensions

--- a/contracts/token/ERC1155/metadata/ERC1155MetadataStorage.sol
+++ b/contracts/token/ERC1155/metadata/ERC1155MetadataStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 /**
  * @title ERC1155 metadata extensions

--- a/contracts/token/ERC1155/metadata/IERC1155Metadata.sol
+++ b/contracts/token/ERC1155/metadata/IERC1155Metadata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC1155MetadataInternal } from './IERC1155MetadataInternal.sol';
 

--- a/contracts/token/ERC1155/metadata/IERC1155Metadata.sol
+++ b/contracts/token/ERC1155/metadata/IERC1155Metadata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC1155MetadataInternal } from './IERC1155MetadataInternal.sol';
 

--- a/contracts/token/ERC1155/metadata/IERC1155MetadataInternal.sol
+++ b/contracts/token/ERC1155/metadata/IERC1155MetadataInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 /**
  * @title Partial ERC1155Metadata interface needed by internal functions

--- a/contracts/token/ERC1155/metadata/IERC1155MetadataInternal.sol
+++ b/contracts/token/ERC1155/metadata/IERC1155MetadataInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 /**
  * @title Partial ERC1155Metadata interface needed by internal functions

--- a/contracts/token/ERC1404/ISolidStateERC1404.sol
+++ b/contracts/token/ERC1404/ISolidStateERC1404.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ISolidStateERC20 } from '../ERC20/ISolidStateERC20.sol';
 import { IERC1404Base } from './base/IERC1404Base.sol';

--- a/contracts/token/ERC1404/ISolidStateERC1404.sol
+++ b/contracts/token/ERC1404/ISolidStateERC1404.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ISolidStateERC20 } from '../ERC20/ISolidStateERC20.sol';
 import { IERC1404Base } from './base/IERC1404Base.sol';

--- a/contracts/token/ERC1404/SolidStateERC1404.sol
+++ b/contracts/token/ERC1404/SolidStateERC1404.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { SolidStateERC20 } from '../ERC20/SolidStateERC20.sol';
 import { ERC20BaseInternal } from '../ERC20/base/ERC20BaseInternal.sol';

--- a/contracts/token/ERC1404/SolidStateERC1404.sol
+++ b/contracts/token/ERC1404/SolidStateERC1404.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { SolidStateERC20 } from '../ERC20/SolidStateERC20.sol';
 import { ERC20BaseInternal } from '../ERC20/base/ERC20BaseInternal.sol';

--- a/contracts/token/ERC1404/SolidStateERC1404Mock.sol
+++ b/contracts/token/ERC1404/SolidStateERC1404Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { SolidStateERC1404 } from './SolidStateERC1404.sol';
 

--- a/contracts/token/ERC1404/SolidStateERC1404Mock.sol
+++ b/contracts/token/ERC1404/SolidStateERC1404Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { SolidStateERC1404 } from './SolidStateERC1404.sol';
 

--- a/contracts/token/ERC1404/base/ERC1404Base.sol
+++ b/contracts/token/ERC1404/base/ERC1404Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC1404 } from '../../../interfaces/IERC1404.sol';
 import { ERC20Base, ERC20BaseInternal } from '../../ERC20/base/ERC20Base.sol';

--- a/contracts/token/ERC1404/base/ERC1404Base.sol
+++ b/contracts/token/ERC1404/base/ERC1404Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC1404 } from '../../../interfaces/IERC1404.sol';
 import { ERC20Base, ERC20BaseInternal } from '../../ERC20/base/ERC20Base.sol';

--- a/contracts/token/ERC1404/base/ERC1404BaseInternal.sol
+++ b/contracts/token/ERC1404/base/ERC1404BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC1404 } from '../../../interfaces/IERC1404.sol';
 import { ERC20BaseInternal } from '../../ERC20/base/ERC20BaseInternal.sol';

--- a/contracts/token/ERC1404/base/ERC1404BaseInternal.sol
+++ b/contracts/token/ERC1404/base/ERC1404BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC1404 } from '../../../interfaces/IERC1404.sol';
 import { ERC20BaseInternal } from '../../ERC20/base/ERC20BaseInternal.sol';

--- a/contracts/token/ERC1404/base/ERC1404BaseMock.sol
+++ b/contracts/token/ERC1404/base/ERC1404BaseMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC1404Base } from './ERC1404Base.sol';
 

--- a/contracts/token/ERC1404/base/ERC1404BaseMock.sol
+++ b/contracts/token/ERC1404/base/ERC1404BaseMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC1404Base } from './ERC1404Base.sol';
 

--- a/contracts/token/ERC1404/base/ERC1404BaseStorage.sol
+++ b/contracts/token/ERC1404/base/ERC1404BaseStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 library ERC1404BaseStorage {
     struct Layout {

--- a/contracts/token/ERC1404/base/ERC1404BaseStorage.sol
+++ b/contracts/token/ERC1404/base/ERC1404BaseStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 library ERC1404BaseStorage {
     struct Layout {

--- a/contracts/token/ERC1404/base/IERC1404Base.sol
+++ b/contracts/token/ERC1404/base/IERC1404Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC1404 } from '../../../interfaces/IERC1404.sol';
 import { IERC1404BaseInternal } from './IERC1404BaseInternal.sol';

--- a/contracts/token/ERC1404/base/IERC1404Base.sol
+++ b/contracts/token/ERC1404/base/IERC1404Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC1404 } from '../../../interfaces/IERC1404.sol';
 import { IERC1404BaseInternal } from './IERC1404BaseInternal.sol';

--- a/contracts/token/ERC1404/base/IERC1404BaseInternal.sol
+++ b/contracts/token/ERC1404/base/IERC1404BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC1404Internal } from '../../../interfaces/IERC1404Internal.sol';
 import { IERC20BaseInternal } from '../../ERC20/base/IERC20BaseInternal.sol';

--- a/contracts/token/ERC1404/base/IERC1404BaseInternal.sol
+++ b/contracts/token/ERC1404/base/IERC1404BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC1404Internal } from '../../../interfaces/IERC1404Internal.sol';
 import { IERC20BaseInternal } from '../../ERC20/base/IERC20BaseInternal.sol';

--- a/contracts/token/ERC20/ISolidStateERC20.sol
+++ b/contracts/token/ERC20/ISolidStateERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC20Base } from './base/IERC20Base.sol';
 import { IERC20Extended } from './extended/IERC20Extended.sol';

--- a/contracts/token/ERC20/ISolidStateERC20.sol
+++ b/contracts/token/ERC20/ISolidStateERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC20Base } from './base/IERC20Base.sol';
 import { IERC20Extended } from './extended/IERC20Extended.sol';

--- a/contracts/token/ERC20/SolidStateERC20.sol
+++ b/contracts/token/ERC20/SolidStateERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ISolidStateERC20 } from './ISolidStateERC20.sol';
 import { ERC20Base } from './base/ERC20Base.sol';

--- a/contracts/token/ERC20/SolidStateERC20.sol
+++ b/contracts/token/ERC20/SolidStateERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ISolidStateERC20 } from './ISolidStateERC20.sol';
 import { ERC20Base } from './base/ERC20Base.sol';

--- a/contracts/token/ERC20/SolidStateERC20Mock.sol
+++ b/contracts/token/ERC20/SolidStateERC20Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { SolidStateERC20 } from './SolidStateERC20.sol';
 

--- a/contracts/token/ERC20/SolidStateERC20Mock.sol
+++ b/contracts/token/ERC20/SolidStateERC20Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { SolidStateERC20 } from './SolidStateERC20.sol';
 

--- a/contracts/token/ERC20/base/ERC20Base.sol
+++ b/contracts/token/ERC20/base/ERC20Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC20 } from '../../../interfaces/IERC20.sol';
 import { IERC20Base } from './IERC20Base.sol';

--- a/contracts/token/ERC20/base/ERC20Base.sol
+++ b/contracts/token/ERC20/base/ERC20Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC20 } from '../../../interfaces/IERC20.sol';
 import { IERC20Base } from './IERC20Base.sol';

--- a/contracts/token/ERC20/base/ERC20BaseInternal.sol
+++ b/contracts/token/ERC20/base/ERC20BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC20BaseInternal } from './IERC20BaseInternal.sol';
 import { ERC20BaseStorage } from './ERC20BaseStorage.sol';

--- a/contracts/token/ERC20/base/ERC20BaseInternal.sol
+++ b/contracts/token/ERC20/base/ERC20BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC20BaseInternal } from './IERC20BaseInternal.sol';
 import { ERC20BaseStorage } from './ERC20BaseStorage.sol';

--- a/contracts/token/ERC20/base/ERC20BaseMock.sol
+++ b/contracts/token/ERC20/base/ERC20BaseMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC20Base } from './ERC20Base.sol';
 

--- a/contracts/token/ERC20/base/ERC20BaseMock.sol
+++ b/contracts/token/ERC20/base/ERC20BaseMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC20Base } from './ERC20Base.sol';
 

--- a/contracts/token/ERC20/base/ERC20BaseStorage.sol
+++ b/contracts/token/ERC20/base/ERC20BaseStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 library ERC20BaseStorage {
     struct Layout {

--- a/contracts/token/ERC20/base/ERC20BaseStorage.sol
+++ b/contracts/token/ERC20/base/ERC20BaseStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 library ERC20BaseStorage {
     struct Layout {

--- a/contracts/token/ERC20/base/IERC20Base.sol
+++ b/contracts/token/ERC20/base/IERC20Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC20 } from '../../../interfaces/IERC20.sol';
 import { IERC20BaseInternal } from './IERC20BaseInternal.sol';

--- a/contracts/token/ERC20/base/IERC20Base.sol
+++ b/contracts/token/ERC20/base/IERC20Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC20 } from '../../../interfaces/IERC20.sol';
 import { IERC20BaseInternal } from './IERC20BaseInternal.sol';

--- a/contracts/token/ERC20/base/IERC20BaseInternal.sol
+++ b/contracts/token/ERC20/base/IERC20BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC20Internal } from '../../../interfaces/IERC20Internal.sol';
 

--- a/contracts/token/ERC20/base/IERC20BaseInternal.sol
+++ b/contracts/token/ERC20/base/IERC20BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC20Internal } from '../../../interfaces/IERC20Internal.sol';
 

--- a/contracts/token/ERC20/extended/ERC20Extended.sol
+++ b/contracts/token/ERC20/extended/ERC20Extended.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC20Extended } from './IERC20Extended.sol';
 import { ERC20ExtendedInternal } from './ERC20ExtendedInternal.sol';

--- a/contracts/token/ERC20/extended/ERC20Extended.sol
+++ b/contracts/token/ERC20/extended/ERC20Extended.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC20Extended } from './IERC20Extended.sol';
 import { ERC20ExtendedInternal } from './ERC20ExtendedInternal.sol';

--- a/contracts/token/ERC20/extended/ERC20ExtendedInternal.sol
+++ b/contracts/token/ERC20/extended/ERC20ExtendedInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC20BaseInternal, ERC20BaseStorage } from '../base/ERC20Base.sol';
 import { IERC20ExtendedInternal } from './IERC20ExtendedInternal.sol';

--- a/contracts/token/ERC20/extended/ERC20ExtendedInternal.sol
+++ b/contracts/token/ERC20/extended/ERC20ExtendedInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC20BaseInternal, ERC20BaseStorage } from '../base/ERC20Base.sol';
 import { IERC20ExtendedInternal } from './IERC20ExtendedInternal.sol';

--- a/contracts/token/ERC20/extended/ERC20ExtendedMock.sol
+++ b/contracts/token/ERC20/extended/ERC20ExtendedMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC20Base } from '../base/ERC20Base.sol';
 import { ERC20Extended } from './ERC20Extended.sol';

--- a/contracts/token/ERC20/extended/ERC20ExtendedMock.sol
+++ b/contracts/token/ERC20/extended/ERC20ExtendedMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC20Base } from '../base/ERC20Base.sol';
 import { ERC20Extended } from './ERC20Extended.sol';

--- a/contracts/token/ERC20/extended/IERC20Extended.sol
+++ b/contracts/token/ERC20/extended/IERC20Extended.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC20ExtendedInternal } from './IERC20ExtendedInternal.sol';
 

--- a/contracts/token/ERC20/extended/IERC20Extended.sol
+++ b/contracts/token/ERC20/extended/IERC20Extended.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC20ExtendedInternal } from './IERC20ExtendedInternal.sol';
 

--- a/contracts/token/ERC20/extended/IERC20ExtendedInternal.sol
+++ b/contracts/token/ERC20/extended/IERC20ExtendedInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC20BaseInternal } from '../base/IERC20BaseInternal.sol';
 

--- a/contracts/token/ERC20/extended/IERC20ExtendedInternal.sol
+++ b/contracts/token/ERC20/extended/IERC20ExtendedInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC20BaseInternal } from '../base/IERC20BaseInternal.sol';
 

--- a/contracts/token/ERC20/implicit_approval/ERC20ImplicitApproval.sol
+++ b/contracts/token/ERC20/implicit_approval/ERC20ImplicitApproval.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC20Base } from '../base/ERC20Base.sol';
 import { ERC20BaseInternal } from '../base/ERC20BaseInternal.sol';

--- a/contracts/token/ERC20/implicit_approval/ERC20ImplicitApproval.sol
+++ b/contracts/token/ERC20/implicit_approval/ERC20ImplicitApproval.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC20Base } from '../base/ERC20Base.sol';
 import { ERC20BaseInternal } from '../base/ERC20BaseInternal.sol';

--- a/contracts/token/ERC20/implicit_approval/ERC20ImplicitApprovalInternal.sol
+++ b/contracts/token/ERC20/implicit_approval/ERC20ImplicitApprovalInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC20BaseInternal } from '../base/ERC20BaseInternal.sol';
 import { ERC20ImplicitApprovalStorage } from './ERC20ImplicitApprovalStorage.sol';

--- a/contracts/token/ERC20/implicit_approval/ERC20ImplicitApprovalInternal.sol
+++ b/contracts/token/ERC20/implicit_approval/ERC20ImplicitApprovalInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC20BaseInternal } from '../base/ERC20BaseInternal.sol';
 import { ERC20ImplicitApprovalStorage } from './ERC20ImplicitApprovalStorage.sol';

--- a/contracts/token/ERC20/implicit_approval/ERC20ImplicitApprovalMock.sol
+++ b/contracts/token/ERC20/implicit_approval/ERC20ImplicitApprovalMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC20ImplicitApproval } from './ERC20ImplicitApproval.sol';
 import { ERC20ImplicitApprovalStorage } from './ERC20ImplicitApprovalStorage.sol';

--- a/contracts/token/ERC20/implicit_approval/ERC20ImplicitApprovalMock.sol
+++ b/contracts/token/ERC20/implicit_approval/ERC20ImplicitApprovalMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC20ImplicitApproval } from './ERC20ImplicitApproval.sol';
 import { ERC20ImplicitApprovalStorage } from './ERC20ImplicitApprovalStorage.sol';

--- a/contracts/token/ERC20/implicit_approval/ERC20ImplicitApprovalStorage.sol
+++ b/contracts/token/ERC20/implicit_approval/ERC20ImplicitApprovalStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 library ERC20ImplicitApprovalStorage {
     struct Layout {

--- a/contracts/token/ERC20/implicit_approval/ERC20ImplicitApprovalStorage.sol
+++ b/contracts/token/ERC20/implicit_approval/ERC20ImplicitApprovalStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 library ERC20ImplicitApprovalStorage {
     struct Layout {

--- a/contracts/token/ERC20/implicit_approval/IERC20ImplicitApproval.sol
+++ b/contracts/token/ERC20/implicit_approval/IERC20ImplicitApproval.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC20Base } from '../base/IERC20Base.sol';
 

--- a/contracts/token/ERC20/implicit_approval/IERC20ImplicitApproval.sol
+++ b/contracts/token/ERC20/implicit_approval/IERC20ImplicitApproval.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC20Base } from '../base/IERC20Base.sol';
 

--- a/contracts/token/ERC20/metadata/ERC20Metadata.sol
+++ b/contracts/token/ERC20/metadata/ERC20Metadata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC20Metadata } from './IERC20Metadata.sol';
 import { ERC20MetadataInternal } from './ERC20MetadataInternal.sol';

--- a/contracts/token/ERC20/metadata/ERC20Metadata.sol
+++ b/contracts/token/ERC20/metadata/ERC20Metadata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC20Metadata } from './IERC20Metadata.sol';
 import { ERC20MetadataInternal } from './ERC20MetadataInternal.sol';

--- a/contracts/token/ERC20/metadata/ERC20MetadataInternal.sol
+++ b/contracts/token/ERC20/metadata/ERC20MetadataInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC20MetadataInternal } from './IERC20MetadataInternal.sol';
 import { ERC20MetadataStorage } from './ERC20MetadataStorage.sol';

--- a/contracts/token/ERC20/metadata/ERC20MetadataInternal.sol
+++ b/contracts/token/ERC20/metadata/ERC20MetadataInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC20MetadataInternal } from './IERC20MetadataInternal.sol';
 import { ERC20MetadataStorage } from './ERC20MetadataStorage.sol';

--- a/contracts/token/ERC20/metadata/ERC20MetadataMock.sol
+++ b/contracts/token/ERC20/metadata/ERC20MetadataMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC20Metadata } from './ERC20Metadata.sol';
 

--- a/contracts/token/ERC20/metadata/ERC20MetadataMock.sol
+++ b/contracts/token/ERC20/metadata/ERC20MetadataMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC20Metadata } from './ERC20Metadata.sol';
 

--- a/contracts/token/ERC20/metadata/ERC20MetadataStorage.sol
+++ b/contracts/token/ERC20/metadata/ERC20MetadataStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 library ERC20MetadataStorage {
     struct Layout {

--- a/contracts/token/ERC20/metadata/ERC20MetadataStorage.sol
+++ b/contracts/token/ERC20/metadata/ERC20MetadataStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 library ERC20MetadataStorage {
     struct Layout {

--- a/contracts/token/ERC20/metadata/IERC20Metadata.sol
+++ b/contracts/token/ERC20/metadata/IERC20Metadata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC20MetadataInternal } from './IERC20MetadataInternal.sol';
 

--- a/contracts/token/ERC20/metadata/IERC20Metadata.sol
+++ b/contracts/token/ERC20/metadata/IERC20Metadata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC20MetadataInternal } from './IERC20MetadataInternal.sol';
 

--- a/contracts/token/ERC20/metadata/IERC20MetadataInternal.sol
+++ b/contracts/token/ERC20/metadata/IERC20MetadataInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 /**
  * @title ERC20 metadata internal interface

--- a/contracts/token/ERC20/metadata/IERC20MetadataInternal.sol
+++ b/contracts/token/ERC20/metadata/IERC20MetadataInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 /**
  * @title ERC20 metadata internal interface

--- a/contracts/token/ERC20/permit/ERC20Permit.sol
+++ b/contracts/token/ERC20/permit/ERC20Permit.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC20Base } from '../base/ERC20Base.sol';
 import { ERC20Metadata } from '../metadata/ERC20Metadata.sol';

--- a/contracts/token/ERC20/permit/ERC20Permit.sol
+++ b/contracts/token/ERC20/permit/ERC20Permit.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC20Base } from '../base/ERC20Base.sol';
 import { ERC20Metadata } from '../metadata/ERC20Metadata.sol';

--- a/contracts/token/ERC20/permit/ERC20PermitInternal.sol
+++ b/contracts/token/ERC20/permit/ERC20PermitInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ECDSA } from '../../../cryptography/ECDSA.sol';
 import { EIP712 } from '../../../cryptography/EIP712.sol';

--- a/contracts/token/ERC20/permit/ERC20PermitInternal.sol
+++ b/contracts/token/ERC20/permit/ERC20PermitInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ECDSA } from '../../../cryptography/ECDSA.sol';
 import { EIP712 } from '../../../cryptography/EIP712.sol';

--- a/contracts/token/ERC20/permit/ERC20PermitMock.sol
+++ b/contracts/token/ERC20/permit/ERC20PermitMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC20Base } from '../base/ERC20Base.sol';
 import { ERC20MetadataStorage } from '../metadata/ERC20MetadataStorage.sol';

--- a/contracts/token/ERC20/permit/ERC20PermitMock.sol
+++ b/contracts/token/ERC20/permit/ERC20PermitMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC20Base } from '../base/ERC20Base.sol';
 import { ERC20MetadataStorage } from '../metadata/ERC20MetadataStorage.sol';

--- a/contracts/token/ERC20/permit/ERC20PermitStorage.sol
+++ b/contracts/token/ERC20/permit/ERC20PermitStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 library ERC20PermitStorage {
     struct Layout {

--- a/contracts/token/ERC20/permit/ERC20PermitStorage.sol
+++ b/contracts/token/ERC20/permit/ERC20PermitStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 library ERC20PermitStorage {
     struct Layout {

--- a/contracts/token/ERC20/permit/IERC20Permit.sol
+++ b/contracts/token/ERC20/permit/IERC20Permit.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC20Metadata } from '../metadata/IERC20Metadata.sol';
 import { IERC2612 } from './IERC2612.sol';

--- a/contracts/token/ERC20/permit/IERC20Permit.sol
+++ b/contracts/token/ERC20/permit/IERC20Permit.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC20Metadata } from '../metadata/IERC20Metadata.sol';
 import { IERC2612 } from './IERC2612.sol';

--- a/contracts/token/ERC20/permit/IERC20PermitInternal.sol
+++ b/contracts/token/ERC20/permit/IERC20PermitInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC2612Internal } from './IERC2612Internal.sol';
 

--- a/contracts/token/ERC20/permit/IERC20PermitInternal.sol
+++ b/contracts/token/ERC20/permit/IERC20PermitInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC2612Internal } from './IERC2612Internal.sol';
 

--- a/contracts/token/ERC20/permit/IERC2612.sol
+++ b/contracts/token/ERC20/permit/IERC2612.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC2612Internal } from './IERC2612Internal.sol';
 

--- a/contracts/token/ERC20/permit/IERC2612.sol
+++ b/contracts/token/ERC20/permit/IERC2612.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC2612Internal } from './IERC2612Internal.sol';
 

--- a/contracts/token/ERC20/permit/IERC2612Internal.sol
+++ b/contracts/token/ERC20/permit/IERC2612Internal.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 interface IERC2612Internal {}

--- a/contracts/token/ERC20/permit/IERC2612Internal.sol
+++ b/contracts/token/ERC20/permit/IERC2612Internal.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 interface IERC2612Internal {}

--- a/contracts/token/ERC20/snapshot/ERC20Snapshot.sol
+++ b/contracts/token/ERC20/snapshot/ERC20Snapshot.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { Math } from '../../../utils/Math.sol';
 import { ERC20SnapshotInternal, ERC20SnapshotStorage } from './ERC20SnapshotInternal.sol';

--- a/contracts/token/ERC20/snapshot/ERC20Snapshot.sol
+++ b/contracts/token/ERC20/snapshot/ERC20Snapshot.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { Math } from '../../../utils/Math.sol';
 import { ERC20SnapshotInternal, ERC20SnapshotStorage } from './ERC20SnapshotInternal.sol';

--- a/contracts/token/ERC20/snapshot/ERC20SnapshotInternal.sol
+++ b/contracts/token/ERC20/snapshot/ERC20SnapshotInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC20BaseInternal } from '../base/ERC20Base.sol';
 import { ERC20SnapshotStorage } from './ERC20SnapshotStorage.sol';

--- a/contracts/token/ERC20/snapshot/ERC20SnapshotInternal.sol
+++ b/contracts/token/ERC20/snapshot/ERC20SnapshotInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC20BaseInternal } from '../base/ERC20Base.sol';
 import { ERC20SnapshotStorage } from './ERC20SnapshotStorage.sol';

--- a/contracts/token/ERC20/snapshot/ERC20SnapshotStorage.sol
+++ b/contracts/token/ERC20/snapshot/ERC20SnapshotStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 library ERC20SnapshotStorage {
     struct Snapshots {

--- a/contracts/token/ERC20/snapshot/ERC20SnapshotStorage.sol
+++ b/contracts/token/ERC20/snapshot/ERC20SnapshotStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 library ERC20SnapshotStorage {
     struct Snapshots {

--- a/contracts/token/ERC4626/ISolidStateERC4626.sol
+++ b/contracts/token/ERC4626/ISolidStateERC4626.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ISolidStateERC20 } from '../ERC20/ISolidStateERC20.sol';
 import { IERC4626Base } from './base/IERC4626Base.sol';

--- a/contracts/token/ERC4626/ISolidStateERC4626.sol
+++ b/contracts/token/ERC4626/ISolidStateERC4626.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ISolidStateERC20 } from '../ERC20/ISolidStateERC20.sol';
 import { IERC4626Base } from './base/IERC4626Base.sol';

--- a/contracts/token/ERC4626/SolidStateERC4626.sol
+++ b/contracts/token/ERC4626/SolidStateERC4626.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC20MetadataInternal } from '../ERC20/metadata/ERC20MetadataInternal.sol';
 import { ERC20PermitInternal } from '../ERC20/permit/ERC20PermitInternal.sol';

--- a/contracts/token/ERC4626/SolidStateERC4626.sol
+++ b/contracts/token/ERC4626/SolidStateERC4626.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC20MetadataInternal } from '../ERC20/metadata/ERC20MetadataInternal.sol';
 import { ERC20PermitInternal } from '../ERC20/permit/ERC20PermitInternal.sol';

--- a/contracts/token/ERC4626/SolidStateERC4626Mock.sol
+++ b/contracts/token/ERC4626/SolidStateERC4626Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC20MetadataStorage } from '../ERC20/metadata/ERC20MetadataStorage.sol';
 import { SolidStateERC4626 } from './SolidStateERC4626.sol';

--- a/contracts/token/ERC4626/SolidStateERC4626Mock.sol
+++ b/contracts/token/ERC4626/SolidStateERC4626Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC20MetadataStorage } from '../ERC20/metadata/ERC20MetadataStorage.sol';
 import { SolidStateERC4626 } from './SolidStateERC4626.sol';

--- a/contracts/token/ERC4626/base/ERC4626Base.sol
+++ b/contracts/token/ERC4626/base/ERC4626Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC4626 } from '../../../interfaces/IERC4626.sol';
 import { IERC4626 } from '../../../interfaces/IERC4626.sol';

--- a/contracts/token/ERC4626/base/ERC4626Base.sol
+++ b/contracts/token/ERC4626/base/ERC4626Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC4626 } from '../../../interfaces/IERC4626.sol';
 import { IERC4626 } from '../../../interfaces/IERC4626.sol';

--- a/contracts/token/ERC4626/base/ERC4626BaseInternal.sol
+++ b/contracts/token/ERC4626/base/ERC4626BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC20 } from '../../../interfaces/IERC20.sol';
 import { SafeERC20 } from '../../../utils/SafeERC20.sol';

--- a/contracts/token/ERC4626/base/ERC4626BaseInternal.sol
+++ b/contracts/token/ERC4626/base/ERC4626BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC20 } from '../../../interfaces/IERC20.sol';
 import { SafeERC20 } from '../../../utils/SafeERC20.sol';

--- a/contracts/token/ERC4626/base/ERC4626BaseMock.sol
+++ b/contracts/token/ERC4626/base/ERC4626BaseMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC20MetadataStorage } from '../../ERC20/metadata/ERC20MetadataStorage.sol';
 import { ERC4626Base } from './ERC4626Base.sol';

--- a/contracts/token/ERC4626/base/ERC4626BaseMock.sol
+++ b/contracts/token/ERC4626/base/ERC4626BaseMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC20MetadataStorage } from '../../ERC20/metadata/ERC20MetadataStorage.sol';
 import { ERC4626Base } from './ERC4626Base.sol';

--- a/contracts/token/ERC4626/base/ERC4626BaseStorage.sol
+++ b/contracts/token/ERC4626/base/ERC4626BaseStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 library ERC4626BaseStorage {
     struct Layout {

--- a/contracts/token/ERC4626/base/ERC4626BaseStorage.sol
+++ b/contracts/token/ERC4626/base/ERC4626BaseStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 library ERC4626BaseStorage {
     struct Layout {

--- a/contracts/token/ERC4626/base/IERC4626Base.sol
+++ b/contracts/token/ERC4626/base/IERC4626Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC4626 } from '../../../interfaces/IERC4626.sol';
 import { IERC4626BaseInternal } from './IERC4626BaseInternal.sol';

--- a/contracts/token/ERC4626/base/IERC4626Base.sol
+++ b/contracts/token/ERC4626/base/IERC4626Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC4626 } from '../../../interfaces/IERC4626.sol';
 import { IERC4626BaseInternal } from './IERC4626BaseInternal.sol';

--- a/contracts/token/ERC4626/base/IERC4626BaseInternal.sol
+++ b/contracts/token/ERC4626/base/IERC4626BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC4626Internal } from '../../../interfaces/IERC4626Internal.sol';
 

--- a/contracts/token/ERC4626/base/IERC4626BaseInternal.sol
+++ b/contracts/token/ERC4626/base/IERC4626BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC4626Internal } from '../../../interfaces/IERC4626Internal.sol';
 

--- a/contracts/token/ERC721/ISolidStateERC721.sol
+++ b/contracts/token/ERC721/ISolidStateERC721.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC721Base } from './base/IERC721Base.sol';
 import { IERC721Enumerable } from './enumerable/IERC721Enumerable.sol';

--- a/contracts/token/ERC721/ISolidStateERC721.sol
+++ b/contracts/token/ERC721/ISolidStateERC721.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC721Base } from './base/IERC721Base.sol';
 import { IERC721Enumerable } from './enumerable/IERC721Enumerable.sol';

--- a/contracts/token/ERC721/SolidStateERC721.sol
+++ b/contracts/token/ERC721/SolidStateERC721.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC165Base } from '../../introspection/ERC165/base/ERC165Base.sol';
 import { ERC721Base, ERC721BaseInternal } from './base/ERC721Base.sol';

--- a/contracts/token/ERC721/SolidStateERC721.sol
+++ b/contracts/token/ERC721/SolidStateERC721.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC165Base } from '../../introspection/ERC165/base/ERC165Base.sol';
 import { ERC721Base, ERC721BaseInternal } from './base/ERC721Base.sol';

--- a/contracts/token/ERC721/SolidStateERC721Mock.sol
+++ b/contracts/token/ERC721/SolidStateERC721Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC165 } from '../../interfaces/IERC165.sol';
 import { IERC721 } from '../../interfaces/IERC721.sol';

--- a/contracts/token/ERC721/SolidStateERC721Mock.sol
+++ b/contracts/token/ERC721/SolidStateERC721Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC165 } from '../../interfaces/IERC165.sol';
 import { IERC721 } from '../../interfaces/IERC721.sol';

--- a/contracts/token/ERC721/base/ERC721Base.sol
+++ b/contracts/token/ERC721/base/ERC721Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC721 } from '../../../interfaces/IERC721.sol';
 import { IERC721Base } from './IERC721Base.sol';

--- a/contracts/token/ERC721/base/ERC721Base.sol
+++ b/contracts/token/ERC721/base/ERC721Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC721 } from '../../../interfaces/IERC721.sol';
 import { IERC721Base } from './IERC721Base.sol';

--- a/contracts/token/ERC721/base/ERC721BaseInternal.sol
+++ b/contracts/token/ERC721/base/ERC721BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC721Receiver } from '../../../interfaces/IERC721Receiver.sol';
 import { EnumerableMap } from '../../../data/EnumerableMap.sol';

--- a/contracts/token/ERC721/base/ERC721BaseInternal.sol
+++ b/contracts/token/ERC721/base/ERC721BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC721Receiver } from '../../../interfaces/IERC721Receiver.sol';
 import { EnumerableMap } from '../../../data/EnumerableMap.sol';

--- a/contracts/token/ERC721/base/ERC721BaseMock.sol
+++ b/contracts/token/ERC721/base/ERC721BaseMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC165 } from '../../../interfaces/IERC165.sol';
 import { ERC165Base } from '../../../introspection/ERC165/base/ERC165Base.sol';

--- a/contracts/token/ERC721/base/ERC721BaseMock.sol
+++ b/contracts/token/ERC721/base/ERC721BaseMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC165 } from '../../../interfaces/IERC165.sol';
 import { ERC165Base } from '../../../introspection/ERC165/base/ERC165Base.sol';

--- a/contracts/token/ERC721/base/ERC721BaseStorage.sol
+++ b/contracts/token/ERC721/base/ERC721BaseStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { EnumerableMap } from '../../../data/EnumerableMap.sol';
 import { EnumerableSet } from '../../../data/EnumerableSet.sol';

--- a/contracts/token/ERC721/base/ERC721BaseStorage.sol
+++ b/contracts/token/ERC721/base/ERC721BaseStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { EnumerableMap } from '../../../data/EnumerableMap.sol';
 import { EnumerableSet } from '../../../data/EnumerableSet.sol';

--- a/contracts/token/ERC721/base/IERC721Base.sol
+++ b/contracts/token/ERC721/base/IERC721Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC721 } from '../../../interfaces/IERC721.sol';
 import { IERC721BaseInternal } from './IERC721BaseInternal.sol';

--- a/contracts/token/ERC721/base/IERC721Base.sol
+++ b/contracts/token/ERC721/base/IERC721Base.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC721 } from '../../../interfaces/IERC721.sol';
 import { IERC721BaseInternal } from './IERC721BaseInternal.sol';

--- a/contracts/token/ERC721/base/IERC721BaseInternal.sol
+++ b/contracts/token/ERC721/base/IERC721BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC721Internal } from '../../../interfaces/IERC721Internal.sol';
 

--- a/contracts/token/ERC721/base/IERC721BaseInternal.sol
+++ b/contracts/token/ERC721/base/IERC721BaseInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC721Internal } from '../../../interfaces/IERC721Internal.sol';
 

--- a/contracts/token/ERC721/enumerable/ERC721Enumerable.sol
+++ b/contracts/token/ERC721/enumerable/ERC721Enumerable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { EnumerableMap } from '../../../data/EnumerableMap.sol';
 import { EnumerableSet } from '../../../data/EnumerableSet.sol';

--- a/contracts/token/ERC721/enumerable/ERC721Enumerable.sol
+++ b/contracts/token/ERC721/enumerable/ERC721Enumerable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { EnumerableMap } from '../../../data/EnumerableMap.sol';
 import { EnumerableSet } from '../../../data/EnumerableSet.sol';

--- a/contracts/token/ERC721/enumerable/ERC721EnumerableInternal.sol
+++ b/contracts/token/ERC721/enumerable/ERC721EnumerableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { EnumerableMap } from '../../../data/EnumerableMap.sol';
 import { EnumerableSet } from '../../../data/EnumerableSet.sol';

--- a/contracts/token/ERC721/enumerable/ERC721EnumerableInternal.sol
+++ b/contracts/token/ERC721/enumerable/ERC721EnumerableInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { EnumerableMap } from '../../../data/EnumerableMap.sol';
 import { EnumerableSet } from '../../../data/EnumerableSet.sol';

--- a/contracts/token/ERC721/enumerable/ERC721EnumerableMock.sol
+++ b/contracts/token/ERC721/enumerable/ERC721EnumerableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC165Base } from '../../../introspection/ERC165/base/ERC165Base.sol';
 import { ERC721Base } from '../base/ERC721Base.sol';

--- a/contracts/token/ERC721/enumerable/ERC721EnumerableMock.sol
+++ b/contracts/token/ERC721/enumerable/ERC721EnumerableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC165Base } from '../../../introspection/ERC165/base/ERC165Base.sol';
 import { ERC721Base } from '../base/ERC721Base.sol';

--- a/contracts/token/ERC721/enumerable/IERC721Enumerable.sol
+++ b/contracts/token/ERC721/enumerable/IERC721Enumerable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 interface IERC721Enumerable {
     /**

--- a/contracts/token/ERC721/enumerable/IERC721Enumerable.sol
+++ b/contracts/token/ERC721/enumerable/IERC721Enumerable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 interface IERC721Enumerable {
     /**

--- a/contracts/token/ERC721/metadata/ERC721Metadata.sol
+++ b/contracts/token/ERC721/metadata/ERC721Metadata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC721MetadataInternal } from './ERC721MetadataInternal.sol';
 import { IERC721Metadata } from './IERC721Metadata.sol';

--- a/contracts/token/ERC721/metadata/ERC721Metadata.sol
+++ b/contracts/token/ERC721/metadata/ERC721Metadata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC721MetadataInternal } from './ERC721MetadataInternal.sol';
 import { IERC721Metadata } from './IERC721Metadata.sol';

--- a/contracts/token/ERC721/metadata/ERC721MetadataInternal.sol
+++ b/contracts/token/ERC721/metadata/ERC721MetadataInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { UintUtils } from '../../../utils/UintUtils.sol';
 import { ERC721BaseStorage } from '../base/ERC721BaseStorage.sol';

--- a/contracts/token/ERC721/metadata/ERC721MetadataInternal.sol
+++ b/contracts/token/ERC721/metadata/ERC721MetadataInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { UintUtils } from '../../../utils/UintUtils.sol';
 import { ERC721BaseStorage } from '../base/ERC721BaseStorage.sol';

--- a/contracts/token/ERC721/metadata/ERC721MetadataMock.sol
+++ b/contracts/token/ERC721/metadata/ERC721MetadataMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC165Base } from '../../../introspection/ERC165/base/ERC165Base.sol';
 import { ERC721Metadata } from './ERC721Metadata.sol';

--- a/contracts/token/ERC721/metadata/ERC721MetadataMock.sol
+++ b/contracts/token/ERC721/metadata/ERC721MetadataMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC165Base } from '../../../introspection/ERC165/base/ERC165Base.sol';
 import { ERC721Metadata } from './ERC721Metadata.sol';

--- a/contracts/token/ERC721/metadata/ERC721MetadataStorage.sol
+++ b/contracts/token/ERC721/metadata/ERC721MetadataStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 library ERC721MetadataStorage {
     bytes32 internal constant STORAGE_SLOT =

--- a/contracts/token/ERC721/metadata/ERC721MetadataStorage.sol
+++ b/contracts/token/ERC721/metadata/ERC721MetadataStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 library ERC721MetadataStorage {
     bytes32 internal constant STORAGE_SLOT =

--- a/contracts/token/ERC721/metadata/IERC721Metadata.sol
+++ b/contracts/token/ERC721/metadata/IERC721Metadata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC721MetadataInternal } from './IERC721MetadataInternal.sol';
 

--- a/contracts/token/ERC721/metadata/IERC721Metadata.sol
+++ b/contracts/token/ERC721/metadata/IERC721Metadata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC721MetadataInternal } from './IERC721MetadataInternal.sol';
 

--- a/contracts/token/ERC721/metadata/IERC721MetadataInternal.sol
+++ b/contracts/token/ERC721/metadata/IERC721MetadataInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC721BaseInternal } from '../base/IERC721BaseInternal.sol';
 

--- a/contracts/token/ERC721/metadata/IERC721MetadataInternal.sol
+++ b/contracts/token/ERC721/metadata/IERC721MetadataInternal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC721BaseInternal } from '../base/IERC721BaseInternal.sol';
 

--- a/contracts/token/common/ERC2981/ERC2981.sol
+++ b/contracts/token/common/ERC2981/ERC2981.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC2981 } from '../../../interfaces/IERC2981.sol';
 

--- a/contracts/token/common/ERC2981/ERC2981.sol
+++ b/contracts/token/common/ERC2981/ERC2981.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC2981 } from '../../../interfaces/IERC2981.sol';
 

--- a/contracts/token/common/ERC2981/ERC2981Internal.sol
+++ b/contracts/token/common/ERC2981/ERC2981Internal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ERC2981Storage } from './ERC2981Storage.sol';
 import { IERC2981Internal } from '../../../interfaces/IERC2981Internal.sol';

--- a/contracts/token/common/ERC2981/ERC2981Internal.sol
+++ b/contracts/token/common/ERC2981/ERC2981Internal.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ERC2981Storage } from './ERC2981Storage.sol';
 import { IERC2981Internal } from '../../../interfaces/IERC2981Internal.sol';

--- a/contracts/token/common/ERC2981/ERC2981Mock.sol
+++ b/contracts/token/common/ERC2981/ERC2981Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC165 } from '../../../interfaces/IERC165.sol';
 import { ERC165Base } from '../../../introspection/ERC165/base/ERC165Base.sol';

--- a/contracts/token/common/ERC2981/ERC2981Mock.sol
+++ b/contracts/token/common/ERC2981/ERC2981Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC165 } from '../../../interfaces/IERC165.sol';
 import { ERC165Base } from '../../../introspection/ERC165/base/ERC165Base.sol';

--- a/contracts/token/common/ERC2981/ERC2981Storage.sol
+++ b/contracts/token/common/ERC2981/ERC2981Storage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 library ERC2981Storage {
     struct Layout {

--- a/contracts/token/common/ERC2981/ERC2981Storage.sol
+++ b/contracts/token/common/ERC2981/ERC2981Storage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 library ERC2981Storage {
     struct Layout {

--- a/contracts/utils/AddressUtils.sol
+++ b/contracts/utils/AddressUtils.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { UintUtils } from './UintUtils.sol';
 

--- a/contracts/utils/AddressUtils.sol
+++ b/contracts/utils/AddressUtils.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { UintUtils } from './UintUtils.sol';
 

--- a/contracts/utils/AddressUtilsMock.sol
+++ b/contracts/utils/AddressUtilsMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { AddressUtils } from './AddressUtils.sol';
 

--- a/contracts/utils/AddressUtilsMock.sol
+++ b/contracts/utils/AddressUtilsMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { AddressUtils } from './AddressUtils.sol';
 

--- a/contracts/utils/ArrayUtils.sol
+++ b/contracts/utils/ArrayUtils.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 library ArrayUtils {
     /**

--- a/contracts/utils/ArrayUtils.sol
+++ b/contracts/utils/ArrayUtils.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 library ArrayUtils {
     /**

--- a/contracts/utils/ArrayUtilsMock.sol
+++ b/contracts/utils/ArrayUtilsMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { ArrayUtils } from './ArrayUtils.sol';
 

--- a/contracts/utils/ArrayUtilsMock.sol
+++ b/contracts/utils/ArrayUtilsMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { ArrayUtils } from './ArrayUtils.sol';
 

--- a/contracts/utils/IMulticall.sol
+++ b/contracts/utils/IMulticall.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 /**
  * @title Interface for the Multicall utility contract

--- a/contracts/utils/IMulticall.sol
+++ b/contracts/utils/IMulticall.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 /**
  * @title Interface for the Multicall utility contract

--- a/contracts/utils/Math.sol
+++ b/contracts/utils/Math.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 library Math {
     /**

--- a/contracts/utils/Math.sol
+++ b/contracts/utils/Math.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 library Math {
     /**

--- a/contracts/utils/MathMock.sol
+++ b/contracts/utils/MathMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { Math } from './Math.sol';
 

--- a/contracts/utils/MathMock.sol
+++ b/contracts/utils/MathMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { Math } from './Math.sol';
 

--- a/contracts/utils/Multicall.sol
+++ b/contracts/utils/Multicall.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IMulticall } from './IMulticall.sol';
 

--- a/contracts/utils/Multicall.sol
+++ b/contracts/utils/Multicall.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IMulticall } from './IMulticall.sol';
 

--- a/contracts/utils/MulticallMock.sol
+++ b/contracts/utils/MulticallMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import './Multicall.sol';
 

--- a/contracts/utils/MulticallMock.sol
+++ b/contracts/utils/MulticallMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import './Multicall.sol';
 

--- a/contracts/utils/SafeCast.sol
+++ b/contracts/utils/SafeCast.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 /**
  * @title Helper library for safe casting of uint and int values

--- a/contracts/utils/SafeCast.sol
+++ b/contracts/utils/SafeCast.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 /**
  * @title Helper library for safe casting of uint and int values

--- a/contracts/utils/SafeERC20.sol
+++ b/contracts/utils/SafeERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { IERC20 } from '../interfaces/IERC20.sol';
 import { AddressUtils } from './AddressUtils.sol';

--- a/contracts/utils/SafeERC20.sol
+++ b/contracts/utils/SafeERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { IERC20 } from '../interfaces/IERC20.sol';
 import { AddressUtils } from './AddressUtils.sol';

--- a/contracts/utils/UintUtils.sol
+++ b/contracts/utils/UintUtils.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 /**
  * @title utility functions for uint256 operations

--- a/contracts/utils/UintUtils.sol
+++ b/contracts/utils/UintUtils.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 /**
  * @title utility functions for uint256 operations

--- a/contracts/utils/UintUtilsMock.sol
+++ b/contracts/utils/UintUtilsMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.9;
 
 import { UintUtils } from './UintUtils.sol';
 

--- a/contracts/utils/UintUtilsMock.sol
+++ b/contracts/utils/UintUtilsMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.18;
 
 import { UintUtils } from './UintUtils.sol';
 

--- a/test/pragma.ts
+++ b/test/pragma.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import {
   TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS,
   TASK_COMPILE_SOLIDITY_GET_SOURCE_NAMES,

--- a/test/pragma.ts
+++ b/test/pragma.ts
@@ -1,3 +1,4 @@
+import { expect } from 'chai';
 import {
   TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS,
   TASK_COMPILE_SOLIDITY_GET_SOURCE_NAMES,
@@ -15,21 +16,17 @@ describe('Pragma statements', () => {
     });
     const files = graph.getResolvedFiles();
 
-    const failures = [];
+    const versions = new Set();
 
     for (const file of files) {
-      const versions = file.content.versionPragmas;
-      if (versions.length != 1 || versions[0] != '^0.8.18') {
-        failures.push(file.sourceName);
+      for (const version of file.content.versionPragmas) {
+        versions.add(version);
       }
     }
 
-    if (failures.length > 0) {
-      throw new Error(
-        `inconsistent pragma statement found in files: ${failures.map(
-          (el) => `\n${el}`,
-        )}`,
-      );
-    }
+    expect(versions.size).to.equal(
+      1,
+      `Multiple version pragmas in use: ${Array.from(versions).join(', ')}`,
+    );
   });
 });

--- a/test/pragma.ts
+++ b/test/pragma.ts
@@ -1,0 +1,36 @@
+import { expect } from 'chai';
+import {
+  TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS,
+  TASK_COMPILE_SOLIDITY_GET_SOURCE_NAMES,
+  TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH,
+} from 'hardhat/builtin-tasks/task-names';
+
+describe('Pragma statements', () => {
+  it('are consistent across all files', async () => {
+    const sourcePaths = await hre.run(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS);
+    const sourceNames = await hre.run(TASK_COMPILE_SOLIDITY_GET_SOURCE_NAMES, {
+      sourcePaths,
+    });
+    const graph = await hre.run(TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH, {
+      sourceNames,
+    });
+    const files = graph.getResolvedFiles();
+
+    const failures = [];
+
+    for (const file of files) {
+      const versions = file.content.versionPragmas;
+      if (versions.length != 1 || versions[0] != '^0.8.18') {
+        failures.push(file.sourceName);
+      }
+    }
+
+    if (failures.length > 0) {
+      throw new Error(
+        `inconsistent pragma statement found in files: ${failures.map(
+          (el) => `\n${el}`,
+        )}`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
[Slither](https://github.com/crytic/slither) is becoming an increasingly useful tool for analyzing smart contracts and recognizing vulnerabilities within them. 

When running this tool against the smart contracts in this codebase, it returns several vulnerabilities pertaining to the solidity compiler version used.

<img width="1273" alt="Screenshot 2023-11-21 at 1 42 41 AM" src="https://github.com/solidstate-network/solidstate-solidity/assets/32080359/d7f08345-c033-4b8c-83b9-ed50a6e839e7">


Namely, v0.8.8 contains this bug ([documented here](https://docs.soliditylang.org/en/latest/bugs.html)):


```
{
   "uid": "SOL-2021-4",
    "name": "UserDefinedValueTypesBug",
    "summary": "User defined value types with underlying type shorter than 32 bytes used incorrect storage layout and wasted storage",
    "description": "The compiler did not correctly compute the storage layout of user defined value types based on types that are shorter than 32 bytes. It would always use a full storage slot for these types, even if the underlying type was shorter. This was wasteful and might have problems with tooling or contract upgrades.",
    "link": "https://blog.soliditylang.org/2021/09/29/user-defined-value-types-bug/",
    "introduced": "0.8.8",
    "fixed": "0.8.9",
    "severity": "very low"
},
```

Hence, we can get rid of the warnings from slither and enhance the security of projects that implement this codebase by upgrading the smart contracts to require a more secure version of the solidity compiler (I.E. the proposed 0.8.18 found within these commits). 