### PR TITLE
Rename `forceApprove` back to `safeApprove`

### DIFF
--- a/contracts/utils/SafeERC20.sol
+++ b/contracts/utils/SafeERC20.sol
@@ -35,7 +35,7 @@ library SafeERC20 {
         );
     }
 
-    function forceApprove(
+    function safeApprove(
         IERC20 token,
         address spender,
         uint256 value


### PR DESCRIPTION
Must wait until at least `0.0.61` to merge and release.  See description of #239.