### PR TITLE
Move all implementation to internal contracts

### DIFF
--- a/abi/ERC20Snapshot.json
+++ b/abi/ERC20Snapshot.json
@@ -134,7 +134,7 @@
     "outputs": [
       {
         "internalType": "uint256",
-        "name": "",
+        "name": "balance",
         "type": "uint256"
       }
     ],
@@ -153,7 +153,7 @@
     "outputs": [
       {
         "internalType": "uint256",
-        "name": "",
+        "name": "totalSupply",
         "type": "uint256"
       }
     ],

--- a/abi/IERC20Snapshot.json
+++ b/abi/IERC20Snapshot.json
@@ -45,6 +45,16 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ERC20Snapshot__SnapshotIdDoesNotExists",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ERC20Snapshot__SnapshotIdIsZero",
+    "type": "error"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {
@@ -93,5 +103,48 @@
     ],
     "name": "Transfer",
     "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "snapshotId",
+        "type": "uint256"
+      }
+    ],
+    "name": "balanceOfAt",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "snapshotId",
+        "type": "uint256"
+      }
+    ],
+    "name": "totalSupplyAt",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "totalSupply",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/abi/_ERC20Snapshot.json
+++ b/abi/_ERC20Snapshot.json
@@ -45,6 +45,16 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ERC20Snapshot__SnapshotIdDoesNotExists",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ERC20Snapshot__SnapshotIdIsZero",
+    "type": "error"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {

--- a/abi/_IERC20Snapshot.json
+++ b/abi/_IERC20Snapshot.json
@@ -45,6 +45,16 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ERC20Snapshot__SnapshotIdDoesNotExists",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ERC20Snapshot__SnapshotIdIsZero",
+    "type": "error"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {

--- a/contracts/access/access_control/AccessControlMock.sol
+++ b/contracts/access/access_control/AccessControlMock.sol
@@ -10,15 +10,15 @@ contract AccessControlMock is AccessControl {
         _grantRole(AccessControlStorage.DEFAULT_ADMIN_ROLE, admin);
     }
 
-    function setRoleAdmin(bytes32 role, bytes32 adminRole) public {
+    function setRoleAdmin(bytes32 role, bytes32 adminRole) external {
         _setRoleAdmin(role, adminRole);
     }
 
-    function checkRole(bytes32 role) public view {
+    function checkRole(bytes32 role) external view {
         _checkRole(role);
     }
 
-    function checkRole(bytes32 role, address account) public view {
+    function checkRole(bytes32 role, address account) external view {
         _checkRole(role, account);
     }
 }

--- a/contracts/access/ownable/Ownable.sol
+++ b/contracts/access/ownable/Ownable.sol
@@ -13,14 +13,14 @@ abstract contract Ownable is IOwnable, _Ownable {
     /**
      * @inheritdoc IERC173
      */
-    function owner() public view virtual returns (address) {
+    function owner() external view returns (address) {
         return _owner();
     }
 
     /**
      * @inheritdoc IERC173
      */
-    function transferOwnership(address account) public virtual {
+    function transferOwnership(address account) external {
         _transferOwnership(account);
     }
 }

--- a/contracts/access/ownable/SafeOwnable.sol
+++ b/contracts/access/ownable/SafeOwnable.sol
@@ -14,14 +14,14 @@ abstract contract SafeOwnable is ISafeOwnable, _SafeOwnable, Ownable {
     /**
      * @inheritdoc ISafeOwnable
      */
-    function nomineeOwner() public view virtual returns (address) {
+    function nomineeOwner() external view returns (address) {
         return _nomineeOwner();
     }
 
     /**
      * @inheritdoc ISafeOwnable
      */
-    function acceptOwnership() public virtual {
+    function acceptOwnership() external {
         _acceptOwnership();
     }
 

--- a/contracts/introspection/ERC165/base/ERC165Base.sol
+++ b/contracts/introspection/ERC165/base/ERC165Base.sol
@@ -14,7 +14,9 @@ abstract contract ERC165Base is IERC165Base, _ERC165Base {
     /**
      * @inheritdoc IERC165
      */
-    function supportsInterface(bytes4 interfaceId) public view returns (bool) {
+    function supportsInterface(
+        bytes4 interfaceId
+    ) external view returns (bool) {
         return _supportsInterface(interfaceId);
     }
 }

--- a/contracts/proxy/beacon/BeaconProxyMock.sol
+++ b/contracts/proxy/beacon/BeaconProxyMock.sol
@@ -8,7 +8,7 @@ contract BeaconProxyMock is BeaconProxy {
     address private _beacon;
 
     constructor(address beacon) {
-        setBeacon(beacon);
+        _setBeacon(beacon);
     }
 
     function _getBeacon() internal view override returns (address) {
@@ -19,7 +19,11 @@ contract BeaconProxyMock is BeaconProxy {
         return _getImplementation();
     }
 
-    function setBeacon(address beacon) public {
+    function setBeacon(address beacon) external {
+        _setBeacon(beacon);
+    }
+
+    function _setBeacon(address beacon) private {
         _beacon = beacon;
     }
 

--- a/contracts/proxy/beacon/diamond/DiamondBeaconProxyMock.sol
+++ b/contracts/proxy/beacon/diamond/DiamondBeaconProxyMock.sol
@@ -8,7 +8,7 @@ contract DiamondBeaconProxyMock is DiamondBeaconProxy {
     address private _beacon;
 
     constructor(address beacon) {
-        setBeacon(beacon);
+        _setBeacon(beacon);
     }
 
     function _getBeacon() internal view override returns (address) {
@@ -23,7 +23,11 @@ contract DiamondBeaconProxyMock is DiamondBeaconProxy {
         return _getImplementation(sig);
     }
 
-    function setBeacon(address beacon) public {
+    function setBeacon(address beacon) external {
+        _setBeacon(beacon);
+    }
+
+    function _setBeacon(address beacon) private {
         _beacon = beacon;
     }
 

--- a/contracts/security/partially_pausable/PartiallyPausable.sol
+++ b/contracts/security/partially_pausable/PartiallyPausable.sol
@@ -12,9 +12,7 @@ abstract contract PartiallyPausable is IPartiallyPausable, _PartiallyPausable {
     /**
      * @inheritdoc IPartiallyPausable
      */
-    function partiallyPaused(
-        bytes32 key
-    ) external view virtual returns (bool status) {
+    function partiallyPaused(bytes32 key) external view returns (bool status) {
         status = _partiallyPaused(key);
     }
 }

--- a/contracts/security/pausable/Pausable.sol
+++ b/contracts/security/pausable/Pausable.sol
@@ -12,7 +12,7 @@ abstract contract Pausable is IPausable, _Pausable {
     /**
      * @inheritdoc IPausable
      */
-    function paused() external view virtual returns (bool status) {
+    function paused() external view returns (bool status) {
         status = _paused();
     }
 }

--- a/contracts/token/ERC1155/base/ERC1155Base.sol
+++ b/contracts/token/ERC1155/base/ERC1155Base.sol
@@ -3,10 +3,8 @@
 pragma solidity ^0.8.20;
 
 import { IERC1155 } from '../../../interfaces/IERC1155.sol';
-import { IERC1155Receiver } from '../../../interfaces/IERC1155Receiver.sol';
 import { IERC1155Base } from './IERC1155Base.sol';
 import { _ERC1155Base } from './_ERC1155Base.sol';
-import { ERC1155BaseStorage } from './ERC1155BaseStorage.sol';
 
 /**
  * @title Base ERC1155 contract
@@ -20,7 +18,7 @@ abstract contract ERC1155Base is IERC1155Base, _ERC1155Base {
     function balanceOf(
         address account,
         uint256 id
-    ) public view virtual returns (uint256) {
+    ) external view returns (uint256) {
         return _balanceOf(account, id);
     }
 
@@ -30,24 +28,8 @@ abstract contract ERC1155Base is IERC1155Base, _ERC1155Base {
     function balanceOfBatch(
         address[] memory accounts,
         uint256[] memory ids
-    ) public view virtual returns (uint256[] memory) {
-        if (accounts.length != ids.length)
-            revert ERC1155Base__ArrayLengthMismatch();
-
-        mapping(uint256 => mapping(address => uint256))
-            storage balances = ERC1155BaseStorage.layout().balances;
-
-        uint256[] memory batchBalances = new uint256[](accounts.length);
-
-        unchecked {
-            for (uint256 i; i < accounts.length; i++) {
-                if (accounts[i] == address(0))
-                    revert ERC1155Base__BalanceQueryZeroAddress();
-                batchBalances[i] = balances[ids[i]][accounts[i]];
-            }
-        }
-
-        return batchBalances;
+    ) external view returns (uint256[] memory) {
+        return _balanceOfBatch(accounts, ids);
     }
 
     /**
@@ -56,19 +38,15 @@ abstract contract ERC1155Base is IERC1155Base, _ERC1155Base {
     function isApprovedForAll(
         address account,
         address operator
-    ) public view virtual returns (bool) {
-        return ERC1155BaseStorage.layout().operatorApprovals[account][operator];
+    ) external view returns (bool) {
+        return _isApprovedForAll(account, operator);
     }
 
     /**
      * @inheritdoc IERC1155
      */
-    function setApprovalForAll(address operator, bool status) public virtual {
-        if (msg.sender == operator) revert ERC1155Base__SelfApproval();
-        ERC1155BaseStorage.layout().operatorApprovals[msg.sender][
-            operator
-        ] = status;
-        emit ApprovalForAll(msg.sender, operator, status);
+    function setApprovalForAll(address operator, bool status) external {
+        _setApprovalForAll(operator, status);
     }
 
     /**
@@ -80,10 +58,8 @@ abstract contract ERC1155Base is IERC1155Base, _ERC1155Base {
         uint256 id,
         uint256 amount,
         bytes memory data
-    ) public virtual {
-        if (from != msg.sender && !isApprovedForAll(from, msg.sender))
-            revert ERC1155Base__NotOwnerOrApproved();
-        _safeTransfer(msg.sender, from, to, id, amount, data);
+    ) external {
+        _safeTransferFrom(from, to, id, amount, data);
     }
 
     /**
@@ -95,9 +71,7 @@ abstract contract ERC1155Base is IERC1155Base, _ERC1155Base {
         uint256[] memory ids,
         uint256[] memory amounts,
         bytes memory data
-    ) public virtual {
-        if (from != msg.sender && !isApprovedForAll(from, msg.sender))
-            revert ERC1155Base__NotOwnerOrApproved();
-        _safeTransferBatch(msg.sender, from, to, ids, amounts, data);
+    ) external {
+        _safeBatchTransferFrom(from, to, ids, amounts, data);
     }
 }

--- a/contracts/token/ERC1155/enumerable/ERC1155Enumerable.sol
+++ b/contracts/token/ERC1155/enumerable/ERC1155Enumerable.sol
@@ -2,30 +2,24 @@
 
 pragma solidity ^0.8.20;
 
-import { EnumerableSet } from '../../../data/EnumerableSet.sol';
-import { _ERC1155Base } from '../base/_ERC1155Base.sol';
 import { IERC1155Enumerable } from './IERC1155Enumerable.sol';
 import { _ERC1155Enumerable } from './_ERC1155Enumerable.sol';
-import { ERC1155EnumerableStorage } from './ERC1155EnumerableStorage.sol';
 
 /**
  * @title ERC1155 implementation including enumerable and aggregate functions
  */
 abstract contract ERC1155Enumerable is IERC1155Enumerable, _ERC1155Enumerable {
-    using EnumerableSet for EnumerableSet.AddressSet;
-    using EnumerableSet for EnumerableSet.UintSet;
-
     /**
      * @inheritdoc IERC1155Enumerable
      */
-    function totalSupply(uint256 id) public view virtual returns (uint256) {
+    function totalSupply(uint256 id) external view returns (uint256) {
         return _totalSupply(id);
     }
 
     /**
      * @inheritdoc IERC1155Enumerable
      */
-    function totalHolders(uint256 id) public view virtual returns (uint256) {
+    function totalHolders(uint256 id) external view returns (uint256) {
         return _totalHolders(id);
     }
 
@@ -34,7 +28,7 @@ abstract contract ERC1155Enumerable is IERC1155Enumerable, _ERC1155Enumerable {
      */
     function accountsByToken(
         uint256 id
-    ) public view virtual returns (address[] memory) {
+    ) external view returns (address[] memory) {
         return _accountsByToken(id);
     }
 
@@ -43,7 +37,7 @@ abstract contract ERC1155Enumerable is IERC1155Enumerable, _ERC1155Enumerable {
      */
     function tokensByAccount(
         address account
-    ) public view virtual returns (uint256[] memory) {
+    ) external view returns (uint256[] memory) {
         return _tokensByAccount(account);
     }
 }

--- a/contracts/token/ERC1155/metadata/ERC1155Metadata.sol
+++ b/contracts/token/ERC1155/metadata/ERC1155Metadata.sol
@@ -2,33 +2,17 @@
 
 pragma solidity ^0.8.20;
 
-import { UintUtils } from '../../../utils/UintUtils.sol';
 import { IERC1155Metadata } from './IERC1155Metadata.sol';
 import { _ERC1155Metadata } from './_ERC1155Metadata.sol';
-import { ERC1155MetadataStorage } from './ERC1155MetadataStorage.sol';
 
 /**
  * @title ERC1155 metadata extensions
  */
 abstract contract ERC1155Metadata is IERC1155Metadata, _ERC1155Metadata {
-    using UintUtils for uint256;
-
     /**
      * @notice inheritdoc IERC1155Metadata
      */
-    function uri(uint256 tokenId) public view virtual returns (string memory) {
-        ERC1155MetadataStorage.Layout storage l = ERC1155MetadataStorage
-            .layout();
-
-        string memory tokenIdURI = l.tokenURIs[tokenId];
-        string memory baseURI = l.baseURI;
-
-        if (bytes(baseURI).length == 0) {
-            return tokenIdURI;
-        } else if (bytes(tokenIdURI).length > 0) {
-            return string(abi.encodePacked(baseURI, tokenIdURI));
-        } else {
-            return string(abi.encodePacked(baseURI, tokenId.toDecString()));
-        }
+    function uri(uint256 tokenId) external view returns (string memory) {
+        return _uri(tokenId);
     }
 }

--- a/contracts/token/ERC1155/metadata/ERC1155MetadataMock.sol
+++ b/contracts/token/ERC1155/metadata/ERC1155MetadataMock.sol
@@ -2,7 +2,8 @@
 
 pragma solidity ^0.8.20;
 
-import { ERC1155Metadata, ERC1155MetadataStorage } from './ERC1155Metadata.sol';
+import { ERC1155Metadata } from './ERC1155Metadata.sol';
+import { ERC1155MetadataStorage } from './ERC1155MetadataStorage.sol';
 import { ERC165Base } from '../../../introspection/ERC165/base/ERC165Base.sol';
 
 contract ERC1155MetadataMock is ERC1155Metadata, ERC165Base {

--- a/contracts/token/ERC1155/metadata/_ERC1155Metadata.sol
+++ b/contracts/token/ERC1155/metadata/_ERC1155Metadata.sol
@@ -2,6 +2,7 @@
 
 pragma solidity ^0.8.20;
 
+import { UintUtils } from '../../../utils/UintUtils.sol';
 import { _IERC1155Metadata } from './_IERC1155Metadata.sol';
 import { ERC1155MetadataStorage } from './ERC1155MetadataStorage.sol';
 
@@ -9,6 +10,26 @@ import { ERC1155MetadataStorage } from './ERC1155MetadataStorage.sol';
  * @title ERC1155Metadata internal functions
  */
 abstract contract _ERC1155Metadata is _IERC1155Metadata {
+    using UintUtils for uint256;
+
+    function _uri(
+        uint256 tokenId
+    ) internal view virtual returns (string memory) {
+        ERC1155MetadataStorage.Layout storage l = ERC1155MetadataStorage
+            .layout();
+
+        string memory tokenIdURI = l.tokenURIs[tokenId];
+        string memory baseURI = l.baseURI;
+
+        if (bytes(baseURI).length == 0) {
+            return tokenIdURI;
+        } else if (bytes(tokenIdURI).length > 0) {
+            return string(abi.encodePacked(baseURI, tokenIdURI));
+        } else {
+            return string(abi.encodePacked(baseURI, tokenId.toDecString()));
+        }
+    }
+
     /**
      * @notice set base metadata URI
      * @dev base URI is a non-standard feature adapted from the ERC721 specification

--- a/contracts/token/ERC1404/base/ERC1404Base.sol
+++ b/contracts/token/ERC1404/base/ERC1404Base.sol
@@ -19,7 +19,7 @@ abstract contract ERC1404Base is IERC1404Base, _ERC1404Base, ERC20Base {
         address from,
         address to,
         uint256 amount
-    ) public view returns (uint8) {
+    ) external view returns (uint8) {
         return _detectTransferRestriction(from, to, amount);
     }
 
@@ -29,7 +29,7 @@ abstract contract ERC1404Base is IERC1404Base, _ERC1404Base, ERC20Base {
      */
     function messageForTransferRestriction(
         uint8 restrictionCode
-    ) public view returns (string memory) {
+    ) external view returns (string memory) {
         return _messageForTransferRestriction(restrictionCode);
     }
 

--- a/contracts/token/ERC20/base/ERC20Base.sol
+++ b/contracts/token/ERC20/base/ERC20Base.sol
@@ -39,7 +39,7 @@ abstract contract ERC20Base is IERC20Base, _ERC20Base {
      * @inheritdoc IERC20
      */
     function approve(address spender, uint256 amount) external returns (bool) {
-        return _approve(msg.sender, spender, amount);
+        return _approve(spender, amount);
     }
 
     /**
@@ -49,7 +49,7 @@ abstract contract ERC20Base is IERC20Base, _ERC20Base {
         address recipient,
         uint256 amount
     ) external returns (bool) {
-        return _transfer(msg.sender, recipient, amount);
+        return _transfer(recipient, amount);
     }
 
     /**

--- a/contracts/token/ERC20/base/_ERC20Base.sol
+++ b/contracts/token/ERC20/base/_ERC20Base.sol
@@ -41,6 +41,10 @@ abstract contract _ERC20Base is _IERC20Base {
         return ERC20BaseStorage.layout().allowances[holder][spender];
     }
 
+    function _approve(address spender, uint256 amount) internal returns (bool) {
+        return _approve(msg.sender, spender, amount);
+    }
+
     /**
      * @notice enable spender to spend tokens on behalf of holder
      * @param holder address on whose behalf tokens may be spent
@@ -119,6 +123,13 @@ abstract contract _ERC20Base is _IERC20Base {
         l.totalSupply -= amount;
 
         emit Transfer(account, address(0), amount);
+    }
+
+    function _transfer(
+        address recipient,
+        uint256 amount
+    ) internal returns (bool) {
+        return _transfer(msg.sender, recipient, amount);
     }
 
     /**

--- a/contracts/token/ERC20/permit/ERC20Permit.sol
+++ b/contracts/token/ERC20/permit/ERC20Permit.sol
@@ -26,7 +26,7 @@ abstract contract ERC20Permit is IERC20Permit, _ERC20Permit {
     /**
      * @inheritdoc IERC2612
      */
-    function nonces(address owner) public view returns (uint256) {
+    function nonces(address owner) external view returns (uint256) {
         return _nonces(owner);
     }
 
@@ -41,7 +41,7 @@ abstract contract ERC20Permit is IERC20Permit, _ERC20Permit {
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) public virtual {
+    ) external {
         _permit(owner, spender, amount, deadline, v, r, s);
     }
 }

--- a/contracts/token/ERC20/snapshot/ERC20Snapshot.sol
+++ b/contracts/token/ERC20/snapshot/ERC20Snapshot.sol
@@ -23,7 +23,7 @@ abstract contract ERC20Snapshot is IERC20Snapshot, _ERC20Snapshot {
     function balanceOfAt(
         address account,
         uint256 snapshotId
-    ) public view returns (uint256) {
+    ) external view returns (uint256) {
         (bool snapshotted, uint256 value) = _valueAt(
             snapshotId,
             ERC20SnapshotStorage.layout().accountBalanceSnapshots[account]
@@ -36,7 +36,7 @@ abstract contract ERC20Snapshot is IERC20Snapshot, _ERC20Snapshot {
      * @param snapshotId snapshot id to query
      * @return token supply
      */
-    function totalSupplyAt(uint256 snapshotId) public view returns (uint256) {
+    function totalSupplyAt(uint256 snapshotId) external view returns (uint256) {
         (bool snapshotted, uint256 value) = _valueAt(
             snapshotId,
             ERC20SnapshotStorage.layout().totalSupplySnapshots

--- a/contracts/token/ERC20/snapshot/ERC20Snapshot.sol
+++ b/contracts/token/ERC20/snapshot/ERC20Snapshot.sol
@@ -2,98 +2,29 @@
 
 pragma solidity ^0.8.20;
 
-import { Math } from '../../../utils/Math.sol';
 import { IERC20Snapshot } from './IERC20Snapshot.sol';
 import { _ERC20Snapshot } from './_ERC20Snapshot.sol';
-import { ERC20SnapshotStorage } from './ERC20SnapshotStorage.sol';
 
 /**
  * @title ERC20 base implementation with support for token balance and supply snapshots
  */
 abstract contract ERC20Snapshot is IERC20Snapshot, _ERC20Snapshot {
-    error ERC20Snapshot__SnapshotIdDoesNotExists();
-    error ERC20Snapshot__SnapshotIdIsZero();
-
     /**
-     * @notice query the token balance of given account at given snapshot id
-     * @param account address to query
-     * @param snapshotId snapshot id to query
-     * @return token balance
+     * @inheritdoc IERC20Snapshot
      */
     function balanceOfAt(
         address account,
         uint256 snapshotId
-    ) external view returns (uint256) {
-        (bool snapshotted, uint256 value) = _valueAt(
-            snapshotId,
-            ERC20SnapshotStorage.layout().accountBalanceSnapshots[account]
-        );
-        return snapshotted ? value : _balanceOf(account);
+    ) external view returns (uint256 balance) {
+        balance = _balanceOfAt(account, snapshotId);
     }
 
     /**
-     * @notice query the total minted token supply at given snapshot id
-     * @param snapshotId snapshot id to query
-     * @return token supply
+     * @inheritdoc IERC20Snapshot
      */
-    function totalSupplyAt(uint256 snapshotId) external view returns (uint256) {
-        (bool snapshotted, uint256 value) = _valueAt(
-            snapshotId,
-            ERC20SnapshotStorage.layout().totalSupplySnapshots
-        );
-        return snapshotted ? value : _totalSupply();
-    }
-
-    function _valueAt(
-        uint256 snapshotId,
-        ERC20SnapshotStorage.Snapshots storage snapshots
-    ) private view returns (bool, uint256) {
-        if (snapshotId == 0) revert ERC20Snapshot__SnapshotIdIsZero();
-        ERC20SnapshotStorage.Layout storage l = ERC20SnapshotStorage.layout();
-
-        if (snapshotId > l.snapshotId)
-            revert ERC20Snapshot__SnapshotIdDoesNotExists();
-
-        uint256 index = _findUpperBound(snapshots.ids, snapshotId);
-
-        if (index == snapshots.ids.length) {
-            return (false, 0);
-        } else {
-            return (true, snapshots.values[index]);
-        }
-    }
-
-    /**
-     * @notice find index of first element of array that is greater than or equal to given query
-     * @dev array must be sorted in ascending order and contain no duplicates
-     * @dev derived from https://github.com/OpenZeppelin/openzeppelin-contracts (MIT license)
-     * @param array array to query
-     * @param query element to search for
-     * @return index of query or array length if query is not found or exceeded
-     */
-    function _findUpperBound(
-        uint256[] storage array,
-        uint256 query
-    ) private view returns (uint256) {
-        unchecked {
-            if (array.length == 0) {
-                return 0;
-            }
-
-            uint256 low = 0;
-            uint256 high = array.length;
-
-            while (low < high) {
-                uint256 mid = Math.average(low, high);
-
-                if (array[mid] > query) {
-                    high = mid;
-                } else {
-                    low = mid + 1;
-                }
-            }
-
-            return (low > 0 && array[low - 1] == query) ? low - 1 : low;
-        }
+    function totalSupplyAt(
+        uint256 snapshotId
+    ) external view returns (uint256 totalSupply) {
+        totalSupply = _totalSupplyAt(snapshotId);
     }
 }

--- a/contracts/token/ERC20/snapshot/IERC20Snapshot.sol
+++ b/contracts/token/ERC20/snapshot/IERC20Snapshot.sol
@@ -4,4 +4,24 @@ pragma solidity ^0.8.20;
 
 import { _IERC20Snapshot } from './_IERC20Snapshot.sol';
 
-interface IERC20Snapshot is _IERC20Snapshot {}
+interface IERC20Snapshot is _IERC20Snapshot {
+    /**
+     * @notice query the token balance of given account at given snapshot id
+     * @param account address to query
+     * @param snapshotId snapshot id to query
+     * @return balance token balance
+     */
+    function balanceOfAt(
+        address account,
+        uint256 snapshotId
+    ) external view returns (uint256 balance);
+
+    /**
+     * @notice query the total minted token supply at given snapshot id
+     * @param snapshotId snapshot id to query
+     * @return totalSupply token supply
+     */
+    function totalSupplyAt(
+        uint256 snapshotId
+    ) external view returns (uint256 totalSupply);
+}

--- a/contracts/token/ERC20/snapshot/_ERC20Snapshot.sol
+++ b/contracts/token/ERC20/snapshot/_ERC20Snapshot.sol
@@ -2,6 +2,7 @@
 
 pragma solidity ^0.8.20;
 
+import { Math } from '../../../utils/Math.sol';
 import { _ERC20Base } from '../base/_ERC20Base.sol';
 import { _IERC20Snapshot } from './_IERC20Snapshot.sol';
 import { ERC20SnapshotStorage } from './ERC20SnapshotStorage.sol';
@@ -11,6 +12,38 @@ import { ERC20SnapshotStorage } from './ERC20SnapshotStorage.sol';
  */
 abstract contract _ERC20Snapshot is _IERC20Snapshot, _ERC20Base {
     event Snapshot(uint256 id);
+
+    /**
+     * @notice query the token balance of given account at given snapshot id
+     * @param account address to query
+     * @param snapshotId snapshot id to query
+     * @return token balance
+     */
+    function _balanceOfAt(
+        address account,
+        uint256 snapshotId
+    ) internal view virtual returns (uint256) {
+        (bool snapshotted, uint256 value) = _valueAt(
+            snapshotId,
+            ERC20SnapshotStorage.layout().accountBalanceSnapshots[account]
+        );
+        return snapshotted ? value : _balanceOf(account);
+    }
+
+    /**
+     * @notice query the total minted token supply at given snapshot id
+     * @param snapshotId snapshot id to query
+     * @return token supply
+     */
+    function _totalSupplyAt(
+        uint256 snapshotId
+    ) internal view returns (uint256) {
+        (bool snapshotted, uint256 value) = _valueAt(
+            snapshotId,
+            ERC20SnapshotStorage.layout().totalSupplySnapshots
+        );
+        return snapshotted ? value : _totalSupply();
+    }
 
     function _snapshot() internal virtual returns (uint256) {
         ERC20SnapshotStorage.Layout storage l = ERC20SnapshotStorage.layout();
@@ -74,6 +107,59 @@ abstract contract _ERC20Snapshot is _IERC20Snapshot, _ERC20Base {
         } else {
             _updateAccountSnapshot(to);
             _updateAccountSnapshot(from);
+        }
+    }
+
+    function _valueAt(
+        uint256 snapshotId,
+        ERC20SnapshotStorage.Snapshots storage snapshots
+    ) private view returns (bool, uint256) {
+        if (snapshotId == 0) revert ERC20Snapshot__SnapshotIdIsZero();
+        ERC20SnapshotStorage.Layout storage l = ERC20SnapshotStorage.layout();
+
+        if (snapshotId > l.snapshotId)
+            revert ERC20Snapshot__SnapshotIdDoesNotExists();
+
+        uint256 index = _findUpperBound(snapshots.ids, snapshotId);
+
+        if (index == snapshots.ids.length) {
+            return (false, 0);
+        } else {
+            return (true, snapshots.values[index]);
+        }
+    }
+
+    /**
+     * @notice find index of first element of array that is greater than or equal to given query
+     * @dev array must be sorted in ascending order and contain no duplicates
+     * @dev derived from https://github.com/OpenZeppelin/openzeppelin-contracts (MIT license)
+     * @param array array to query
+     * @param query element to search for
+     * @return index of query or array length if query is not found or exceeded
+     */
+    function _findUpperBound(
+        uint256[] storage array,
+        uint256 query
+    ) private view returns (uint256) {
+        unchecked {
+            if (array.length == 0) {
+                return 0;
+            }
+
+            uint256 low = 0;
+            uint256 high = array.length;
+
+            while (low < high) {
+                uint256 mid = Math.average(low, high);
+
+                if (array[mid] > query) {
+                    high = mid;
+                } else {
+                    low = mid + 1;
+                }
+            }
+
+            return (low > 0 && array[low - 1] == query) ? low - 1 : low;
         }
     }
 }

--- a/contracts/token/ERC20/snapshot/_IERC20Snapshot.sol
+++ b/contracts/token/ERC20/snapshot/_IERC20Snapshot.sol
@@ -4,4 +4,7 @@ pragma solidity ^0.8.20;
 
 import { _IERC20Base } from '../base/_IERC20Base.sol';
 
-interface _IERC20Snapshot is _IERC20Base {}
+interface _IERC20Snapshot is _IERC20Base {
+    error ERC20Snapshot__SnapshotIdDoesNotExists();
+    error ERC20Snapshot__SnapshotIdIsZero();
+}

--- a/contracts/token/ERC721/enumerable/ERC721Enumerable.sol
+++ b/contracts/token/ERC721/enumerable/ERC721Enumerable.sol
@@ -15,7 +15,7 @@ abstract contract ERC721Enumerable is IERC721Enumerable, _ERC721Enumerable {
     /**
      * @inheritdoc IERC721Enumerable
      */
-    function totalSupply() public view returns (uint256) {
+    function totalSupply() external view returns (uint256) {
         return _totalSupply();
     }
 
@@ -25,14 +25,14 @@ abstract contract ERC721Enumerable is IERC721Enumerable, _ERC721Enumerable {
     function tokenOfOwnerByIndex(
         address owner,
         uint256 index
-    ) public view returns (uint256) {
+    ) external view returns (uint256) {
         return _tokenOfOwnerByIndex(owner, index);
     }
 
     /**
      * @inheritdoc IERC721Enumerable
      */
-    function tokenByIndex(uint256 index) public view returns (uint256) {
+    function tokenByIndex(uint256 index) external view returns (uint256) {
         return _tokenByIndex(index);
     }
 }

--- a/contracts/token/ERC721/metadata/ERC721Metadata.sol
+++ b/contracts/token/ERC721/metadata/ERC721Metadata.sol
@@ -12,23 +12,21 @@ abstract contract ERC721Metadata is IERC721Metadata, _ERC721Metadata {
     /**
      * @notice inheritdoc IERC721Metadata
      */
-    function name() external view virtual returns (string memory) {
+    function name() external view returns (string memory) {
         return _name();
     }
 
     /**
      * @notice inheritdoc IERC721Metadata
      */
-    function symbol() external view virtual returns (string memory) {
+    function symbol() external view returns (string memory) {
         return _symbol();
     }
 
     /**
      * @notice inheritdoc IERC721Metadata
      */
-    function tokenURI(
-        uint256 tokenId
-    ) external view virtual returns (string memory) {
+    function tokenURI(uint256 tokenId) external view returns (string memory) {
         return _tokenURI(tokenId);
     }
 }

--- a/contracts/utils/Multicall.sol
+++ b/contracts/utils/Multicall.sol
@@ -15,24 +15,6 @@ abstract contract Multicall is IMulticall, _Multicall {
     function multicall(
         bytes[] calldata data
     ) external returns (bytes[] memory results) {
-        results = new bytes[](data.length);
-
-        unchecked {
-            for (uint256 i; i < data.length; i++) {
-                (bool success, bytes memory returndata) = address(this)
-                    .delegatecall(data[i]);
-
-                if (success) {
-                    results[i] = returndata;
-                } else {
-                    assembly {
-                        returndatacopy(0, 0, returndatasize())
-                        revert(0, returndatasize())
-                    }
-                }
-            }
-        }
-
-        return results;
+        results = _multicall(data);
     }
 }

--- a/contracts/utils/_Multicall.sol
+++ b/contracts/utils/_Multicall.sol
@@ -4,4 +4,28 @@ pragma solidity ^0.8.20;
 
 import { _IMulticall } from './_IMulticall.sol';
 
-abstract contract _Multicall is _IMulticall {}
+abstract contract _Multicall is _IMulticall {
+    function _multicall(
+        bytes[] calldata data
+    ) internal virtual returns (bytes[] memory results) {
+        results = new bytes[](data.length);
+
+        unchecked {
+            for (uint256 i; i < data.length; i++) {
+                (bool success, bytes memory returndata) = address(this)
+                    .delegatecall(data[i]);
+
+                if (success) {
+                    results[i] = returndata;
+                } else {
+                    assembly {
+                        returndatacopy(0, 0, returndatasize())
+                        revert(0, returndatasize())
+                    }
+                }
+            }
+        }
+
+        return results;
+    }
+}


### PR DESCRIPTION
This PR finally removes all `public` and `external virtual` function declarations, and moves all implementation code to internal contracts