### PR TITLE
Add `ERC721` and `ERC1155` extension interfaces

### DIFF
--- a/contracts/interfaces/IERC1155Metadata.sol
+++ b/contracts/interfaces/IERC1155Metadata.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import { _IERC1155Metadata } from './_IERC1155Metadata.sol';
+
+interface IERC1155Metadata is _IERC1155Metadata {
+    /**
+     * @notice get generated URI for given token
+     * @return token URI
+     */
+    function uri(uint256 tokenId) external view returns (string memory);
+}

--- a/contracts/interfaces/IERC721Enumerable.sol
+++ b/contracts/interfaces/IERC721Enumerable.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import { _IERC721Enumerable } from './_IERC721Enumerable.sol';
+
+interface IERC721Enumerable is _IERC721Enumerable {
+    /**
+     * @notice get total token supply
+     * @return total supply
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @notice get token of given owner at given internal storage index
+     * @param owner token holder to query
+     * @param index position in owner's token list to query
+     * @return tokenId id of retrieved token
+     */
+    function tokenOfOwnerByIndex(
+        address owner,
+        uint256 index
+    ) external view returns (uint256 tokenId);
+
+    /**
+     * @notice get token at given internal storage index
+     * @param index position in global token list to query
+     * @return tokenId id of retrieved token
+     */
+    function tokenByIndex(
+        uint256 index
+    ) external view returns (uint256 tokenId);
+}

--- a/contracts/interfaces/IERC721Metadata.sol
+++ b/contracts/interfaces/IERC721Metadata.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import { _IERC721Metadata } from './_IERC721Metadata.sol';
+
+interface IERC721Metadata is _IERC721Metadata {
+    /**
+     * @notice get token name
+     * @return token name
+     */
+    function name() external view returns (string memory);
+
+    /**
+     * @notice get token symbol
+     * @return token symbol
+     */
+    function symbol() external view returns (string memory);
+
+    /**
+     * @notice get generated URI for given token
+     * @return token URI
+     */
+    function tokenURI(uint256 tokenId) external view returns (string memory);
+}

--- a/contracts/interfaces/_IERC1155Metadata.sol
+++ b/contracts/interfaces/_IERC1155Metadata.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+interface _IERC1155Metadata {}

--- a/contracts/interfaces/_IERC1155Metadata.sol
+++ b/contracts/interfaces/_IERC1155Metadata.sol
@@ -2,4 +2,6 @@
 
 pragma solidity ^0.8.20;
 
-interface _IERC1155Metadata {}
+interface _IERC1155Metadata {
+    event URI(string value, uint256 indexed tokenId);
+}

--- a/contracts/interfaces/_IERC721Enumerable.sol
+++ b/contracts/interfaces/_IERC721Enumerable.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+interface _IERC721Enumerable {}

--- a/contracts/interfaces/_IERC721Metadata.sol
+++ b/contracts/interfaces/_IERC721Metadata.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+interface _IERC721Metadata {}

--- a/contracts/token/common/royalty/NFTRoyalty.sol
+++ b/contracts/token/common/royalty/NFTRoyalty.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.20;
 
+import { IERC2981 } from '../../../interfaces/IERC2981.sol';
 import { Introspectable } from '../../../introspection/Introspectable.sol';
 import { INFTRoyalty } from './INFTRoyalty.sol';
-import { ERC2981Storage } from '../../../storage/ERC2981Storage.sol';
 import { _NFTRoyalty } from './_NFTRoyalty.sol';
 
 /**
@@ -12,7 +12,7 @@ import { _NFTRoyalty } from './_NFTRoyalty.sol';
  */
 abstract contract NFTRoyalty is INFTRoyalty, _NFTRoyalty, Introspectable {
     /**
-     * @notice inheritdoc INFTRoyalty
+     * @inheritdoc IERC2981
      */
     function royaltyInfo(
         uint256 tokenId,

--- a/contracts/token/multi/metadata/IMultiTokenMetadata.sol
+++ b/contracts/token/multi/metadata/IMultiTokenMetadata.sol
@@ -2,15 +2,10 @@
 
 pragma solidity ^0.8.20;
 
+import { IERC1155Metadata } from '../../../interfaces/IERC1155Metadata.sol';
 import { _IMultiTokenMetadata } from './_IMultiTokenMetadata.sol';
 
 /**
  * @title MultiTokenMetadata interface
  */
-interface IMultiTokenMetadata is _IMultiTokenMetadata {
-    /**
-     * @notice get generated URI for given token
-     * @return token URI
-     */
-    function uri(uint256 tokenId) external view returns (string memory);
-}
+interface IMultiTokenMetadata is _IMultiTokenMetadata, IERC1155Metadata {}

--- a/contracts/token/multi/metadata/MultiTokenMetadata.sol
+++ b/contracts/token/multi/metadata/MultiTokenMetadata.sol
@@ -13,7 +13,7 @@ abstract contract MultiTokenMetadata is
     _MultiTokenMetadata
 {
     /**
-     * @notice inheritdoc IMultiTokenMetadata
+     * @inheritdoc IMultiTokenMetadata
      */
     function uri(uint256 tokenId) external view returns (string memory) {
         return _uri(tokenId);

--- a/contracts/token/multi/metadata/MultiTokenMetadata.sol
+++ b/contracts/token/multi/metadata/MultiTokenMetadata.sol
@@ -2,6 +2,7 @@
 
 pragma solidity ^0.8.20;
 
+import { IERC1155Metadata } from '../../../interfaces/IERC1155Metadata.sol';
 import { IMultiTokenMetadata } from './IMultiTokenMetadata.sol';
 import { _MultiTokenMetadata } from './_MultiTokenMetadata.sol';
 
@@ -13,7 +14,7 @@ abstract contract MultiTokenMetadata is
     _MultiTokenMetadata
 {
     /**
-     * @inheritdoc IMultiTokenMetadata
+     * @inheritdoc IERC1155Metadata
      */
     function uri(uint256 tokenId) external view returns (string memory) {
         return _uri(tokenId);

--- a/contracts/token/multi/metadata/_IMultiTokenMetadata.sol
+++ b/contracts/token/multi/metadata/_IMultiTokenMetadata.sol
@@ -7,6 +7,4 @@ import { _IERC1155Metadata } from '../../../interfaces/_IERC1155Metadata.sol';
 /**
  * @title Partial MultiTokenMetadata interface needed by internal functions
  */
-interface _IMultiTokenMetadata is _IERC1155Metadata {
-    event URI(string value, uint256 indexed tokenId);
-}
+interface _IMultiTokenMetadata is _IERC1155Metadata {}

--- a/contracts/token/multi/metadata/_IMultiTokenMetadata.sol
+++ b/contracts/token/multi/metadata/_IMultiTokenMetadata.sol
@@ -2,9 +2,11 @@
 
 pragma solidity ^0.8.20;
 
+import { _IERC1155Metadata } from '../../../interfaces/_IERC1155Metadata.sol';
+
 /**
  * @title Partial MultiTokenMetadata interface needed by internal functions
  */
-interface _IMultiTokenMetadata {
+interface _IMultiTokenMetadata is _IERC1155Metadata {
     event URI(string value, uint256 indexed tokenId);
 }

--- a/contracts/token/multi/metadata/_MultiTokenMetadata.sol
+++ b/contracts/token/multi/metadata/_MultiTokenMetadata.sol
@@ -25,10 +25,24 @@ abstract contract _MultiTokenMetadata is _IMultiTokenMetadata {
         if (bytes(baseURI).length == 0) {
             return tokenURI;
         } else if (bytes(tokenURI).length == 0) {
-            return string(abi.encodePacked(baseURI, tokenId.toString(16, 64)));
+            return
+                string(
+                    abi.encodePacked(baseURI, _generateDefaultTokenURI(tokenId))
+                );
         } else {
             return string(abi.encodePacked(baseURI, tokenURI));
         }
+    }
+
+    /**
+     * @notice generate URI component for token id
+     * @dev padded hex string is used to match https://eips.ethereum.org/EIPS/eip-1155#metadata
+     * @return tokenURI token URI component
+     */
+    function _generateDefaultTokenURI(
+        uint256 tokenId
+    ) internal view virtual returns (string memory tokenURI) {
+        tokenURI = tokenId.toString(16, 64);
     }
 
     /**

--- a/contracts/token/multi/metadata/_MultiTokenMetadata.sol
+++ b/contracts/token/multi/metadata/_MultiTokenMetadata.sol
@@ -25,7 +25,7 @@ abstract contract _MultiTokenMetadata is _IMultiTokenMetadata {
         if (bytes(baseURI).length == 0) {
             return tokenURI;
         } else if (bytes(tokenURI).length == 0) {
-            return string(abi.encodePacked(baseURI, tokenId.toDecString()));
+            return string(abi.encodePacked(baseURI, tokenId.toString(16, 64)));
         } else {
             return string(abi.encodePacked(baseURI, tokenURI));
         }

--- a/contracts/token/non_fungible/enumerable/INonFungibleTokenEnumerable.sol
+++ b/contracts/token/non_fungible/enumerable/INonFungibleTokenEnumerable.sol
@@ -2,36 +2,12 @@
 
 pragma solidity ^0.8.20;
 
+import { IERC721Enumerable } from '../../../interfaces/IERC721Enumerable.sol';
 import { INonFungibleToken } from '../INonFungibleToken.sol';
 import { _INonFungibleTokenEnumerable } from './_NonFungibleTokenEnumerable.sol';
 
 interface INonFungibleTokenEnumerable is
     _INonFungibleTokenEnumerable,
-    INonFungibleToken
-{
-    /**
-     * @notice get total token supply
-     * @return total supply
-     */
-    function totalSupply() external view returns (uint256);
-
-    /**
-     * @notice get token of given owner at given internal storage index
-     * @param owner token holder to query
-     * @param index position in owner's token list to query
-     * @return tokenId id of retrieved token
-     */
-    function tokenOfOwnerByIndex(
-        address owner,
-        uint256 index
-    ) external view returns (uint256 tokenId);
-
-    /**
-     * @notice get token at given internal storage index
-     * @param index position in global token list to query
-     * @return tokenId id of retrieved token
-     */
-    function tokenByIndex(
-        uint256 index
-    ) external view returns (uint256 tokenId);
-}
+    INonFungibleToken,
+    IERC721Enumerable
+{}

--- a/contracts/token/non_fungible/enumerable/NonFungibleTokenEnumerable.sol
+++ b/contracts/token/non_fungible/enumerable/NonFungibleTokenEnumerable.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.20;
 import { EnumerableMap } from '../../../data/EnumerableMap.sol';
 import { EnumerableSet } from '../../../data/EnumerableSet.sol';
 import { ERC721Storage } from '../../../storage/ERC721Storage.sol';
+import { IERC721Enumerable } from '../../../interfaces/IERC721Enumerable.sol';
 import { NonFungibleToken } from '../NonFungibleToken.sol';
 import { INonFungibleTokenEnumerable } from './INonFungibleTokenEnumerable.sol';
 import { _NonFungibleTokenEnumerable } from './_NonFungibleTokenEnumerable.sol';
@@ -18,14 +19,14 @@ abstract contract NonFungibleTokenEnumerable is
     using EnumerableSet for EnumerableSet.UintSet;
 
     /**
-     * @inheritdoc INonFungibleTokenEnumerable
+     * @inheritdoc IERC721Enumerable
      */
     function totalSupply() external view returns (uint256) {
         return _totalSupply();
     }
 
     /**
-     * @inheritdoc INonFungibleTokenEnumerable
+     * @inheritdoc IERC721Enumerable
      */
     function tokenOfOwnerByIndex(
         address owner,
@@ -35,7 +36,7 @@ abstract contract NonFungibleTokenEnumerable is
     }
 
     /**
-     * @inheritdoc INonFungibleTokenEnumerable
+     * @inheritdoc IERC721Enumerable
      */
     function tokenByIndex(uint256 index) external view returns (uint256) {
         return _tokenByIndex(index);

--- a/contracts/token/non_fungible/enumerable/_INonFungibleTokenEnumerable.sol
+++ b/contracts/token/non_fungible/enumerable/_INonFungibleTokenEnumerable.sol
@@ -2,6 +2,10 @@
 
 pragma solidity ^0.8.20;
 
+import { _IERC721Enumerable } from '../../../interfaces/_IERC721Enumerable.sol';
 import { _INonFungibleToken } from '../_INonFungibleToken.sol';
 
-interface _INonFungibleTokenEnumerable is _INonFungibleToken {}
+interface _INonFungibleTokenEnumerable is
+    _INonFungibleToken,
+    _IERC721Enumerable
+{}

--- a/contracts/token/non_fungible/metadata/INonFungibleTokenMetadata.sol
+++ b/contracts/token/non_fungible/metadata/INonFungibleTokenMetadata.sol
@@ -2,27 +2,13 @@
 
 pragma solidity ^0.8.20;
 
+import { IERC721Metadata } from '../../../interfaces/IERC721Metadata.sol';
 import { _INonFungibleTokenMetadata } from './_INonFungibleTokenMetadata.sol';
 
 /**
  * @title NonFungibleTokenMetadata interface
  */
-interface INonFungibleTokenMetadata is _INonFungibleTokenMetadata {
-    /**
-     * @notice get token name
-     * @return token name
-     */
-    function name() external view returns (string memory);
-
-    /**
-     * @notice get token symbol
-     * @return token symbol
-     */
-    function symbol() external view returns (string memory);
-
-    /**
-     * @notice get generated URI for given token
-     * @return token URI
-     */
-    function tokenURI(uint256 tokenId) external view returns (string memory);
-}
+interface INonFungibleTokenMetadata is
+    _INonFungibleTokenMetadata,
+    IERC721Metadata
+{}

--- a/contracts/token/non_fungible/metadata/NonFungibleTokenMetadata.sol
+++ b/contracts/token/non_fungible/metadata/NonFungibleTokenMetadata.sol
@@ -2,6 +2,7 @@
 
 pragma solidity ^0.8.20;
 
+import { IERC721Metadata } from '../../../interfaces/IERC721Metadata.sol';
 import { _NonFungibleTokenMetadata } from './_NonFungibleTokenMetadata.sol';
 import { INonFungibleTokenMetadata } from './INonFungibleTokenMetadata.sol';
 
@@ -13,21 +14,21 @@ abstract contract NonFungibleTokenMetadata is
     _NonFungibleTokenMetadata
 {
     /**
-     * @notice inheritdoc INonFungibleTokenMetadata
+     * @inheritdoc IERC721Metadata
      */
     function name() external view returns (string memory) {
         return _name();
     }
 
     /**
-     * @notice inheritdoc INonFungibleTokenMetadata
+     * @inheritdoc IERC721Metadata
      */
     function symbol() external view returns (string memory) {
         return _symbol();
     }
 
     /**
-     * @notice inheritdoc INonFungibleTokenMetadata
+     * @inheritdoc IERC721Metadata
      */
     function tokenURI(uint256 tokenId) external view returns (string memory) {
         return _tokenURI(tokenId);

--- a/contracts/token/non_fungible/metadata/_INonFungibleTokenMetadata.sol
+++ b/contracts/token/non_fungible/metadata/_INonFungibleTokenMetadata.sol
@@ -2,11 +2,12 @@
 
 pragma solidity ^0.8.20;
 
-import { _INonFungibleToken } from '..//_INonFungibleToken.sol';
+import { _IERC721Metadata } from '../../../interfaces/_IERC721Metadata.sol';
+import { _INonFungibleToken } from '../_INonFungibleToken.sol';
 
 /**
  * @title NonFungibleTokenMetadata internal interface
  */
-interface _INonFungibleTokenMetadata is _INonFungibleToken {
+interface _INonFungibleTokenMetadata is _INonFungibleToken, _IERC721Metadata {
     error NonFungibleTokenMetadata__NonExistentToken();
 }

--- a/contracts/token/non_fungible/metadata/_NonFungibleTokenMetadata.sol
+++ b/contracts/token/non_fungible/metadata/_NonFungibleTokenMetadata.sol
@@ -55,7 +55,7 @@ abstract contract _NonFungibleTokenMetadata is
         if (bytes(baseURI).length == 0) {
             return tokenURI;
         } else if (bytes(tokenURI).length == 0) {
-            return string(abi.encodePacked(baseURI, tokenId.toDecString()));
+            return string(abi.encodePacked(baseURI, tokenId.toString(16, 64)));
         } else {
             return string(abi.encodePacked(baseURI, tokenURI));
         }

--- a/contracts/token/non_fungible/metadata/_NonFungibleTokenMetadata.sol
+++ b/contracts/token/non_fungible/metadata/_NonFungibleTokenMetadata.sol
@@ -55,10 +55,24 @@ abstract contract _NonFungibleTokenMetadata is
         if (bytes(baseURI).length == 0) {
             return tokenURI;
         } else if (bytes(tokenURI).length == 0) {
-            return string(abi.encodePacked(baseURI, tokenId.toString(16, 64)));
+            return
+                string(
+                    abi.encodePacked(baseURI, _generateDefaultTokenURI(tokenId))
+                );
         } else {
             return string(abi.encodePacked(baseURI, tokenURI));
         }
+    }
+
+    /**
+     * @notice generate URI component for token id
+     * @dev padded hex string is used to match https://eips.ethereum.org/EIPS/eip-1155#metadata
+     * @return tokenURI token URI component
+     */
+    function _generateDefaultTokenURI(
+        uint256 tokenId
+    ) internal view virtual returns (string memory tokenURI) {
+        tokenURI = tokenId.toString(16, 64);
     }
 
     /**

--- a/spec/token/multi/MultiTokenMetadata.behavior.ts
+++ b/spec/token/multi/MultiTokenMetadata.behavior.ts
@@ -20,6 +20,15 @@ export function describeBehaviorOfMultiTokenMetadata(
       instance = await deploy();
     });
 
+    // TODO: enable for compositions that include ERC165
+    // describeBehaviorOfIntrospectable(
+    //   deploy,
+    //   {
+    //     interfaceIds: ['0x0e89341c'],
+    //   },
+    //   skips,
+    // );
+
     describe('#uri(uint256)', () => {
       it('todo');
     });

--- a/spec/token/non_fungible/NonFungibleTokenEnumerable.behavior.ts
+++ b/spec/token/non_fungible/NonFungibleTokenEnumerable.behavior.ts
@@ -26,6 +26,15 @@ export function describeBehaviorOfNonFungibleTokenEnumerable(
       instance = await deploy();
     });
 
+    // TODO: enable for compositions that include ERC165
+    // describeBehaviorOfIntrospectable(
+    //   deploy,
+    //   {
+    //     interfaceIds: ['0x780e9d63'],
+    //   },
+    //   skips,
+    // );
+
     describe('#totalSupply()', () => {
       it('returns total token supply', async () => {
         expect(await instance.totalSupply()).to.equal(args.supply);

--- a/spec/token/non_fungible/NonFungibleTokenMetadata.behavior.ts
+++ b/spec/token/non_fungible/NonFungibleTokenMetadata.behavior.ts
@@ -22,6 +22,15 @@ export function describeBehaviorOfNonFungibleTokenMetadata(
       instance = await deploy();
     });
 
+    // TODO: enable for compositions that include ERC165
+    // describeBehaviorOfIntrospectable(
+    //   deploy,
+    //   {
+    //     interfaceIds: ['0x5b5e139f'],
+    //   },
+    //   skips,
+    // );
+
     describe('#name()', () => {
       it('returns token name', async () => {
         expect(await instance.name.staticCall()).to.equal(args.name);

--- a/test/token/multi/MultiTokenMetadata.ts
+++ b/test/token/multi/MultiTokenMetadata.ts
@@ -59,5 +59,15 @@ describe('MultiTokenMetadata', () => {
         expect(await instance.$_uri(tokenId)).to.eq(`${baseURI}${tokenURI}`);
       });
     });
+
+    describe('#_generateDefaultTokenURI(uint256)', () => {
+      it('returns padded hex representation of token id', async () => {
+        const tokenId = 1n;
+
+        expect(
+          await instance.$_generateDefaultTokenURI.staticCall(tokenId),
+        ).to.eq(ethers.toBeHex(tokenId, 32).replace('0x', ''));
+      });
+    });
   });
 });

--- a/test/token/multi/MultiTokenMetadata.ts
+++ b/test/token/multi/MultiTokenMetadata.ts
@@ -44,7 +44,9 @@ describe('MultiTokenMetadata', () => {
 
         await instance.$_setBaseURI(baseURI);
 
-        expect(await instance.$_uri(tokenId)).to.eq(`${baseURI}${tokenId}`);
+        expect(await instance.$_uri(tokenId)).to.eq(
+          `${baseURI}${ethers.toBeHex(tokenId, 32).replace('0x', '')}`,
+        );
       });
 
       it('returns concatenation of base URI and token URI if both are set', async () => {

--- a/test/token/non_fungible/NonFungibleTokenMetadata.ts
+++ b/test/token/non_fungible/NonFungibleTokenMetadata.ts
@@ -89,5 +89,15 @@ describe('NonFungibleTokenMetadata', () => {
         });
       });
     });
+
+    describe('#_generateDefaultTokenURI(uint256)', () => {
+      it('returns padded hex representation of token id', async () => {
+        const tokenId = 1n;
+
+        expect(
+          await instance.$_generateDefaultTokenURI.staticCall(tokenId),
+        ).to.eq(ethers.toBeHex(tokenId, 32).replace('0x', ''));
+      });
+    });
   });
 });

--- a/test/token/non_fungible/NonFungibleTokenMetadata.ts
+++ b/test/token/non_fungible/NonFungibleTokenMetadata.ts
@@ -60,7 +60,7 @@ describe('NonFungibleTokenMetadata', () => {
         await instance.$_setBaseURI(baseURI);
 
         expect(await instance.$_tokenURI(tokenId)).to.eq(
-          `${baseURI}${tokenId}`,
+          `${baseURI}${ethers.toBeHex(tokenId, 32).replace('0x', '')}`,
         );
       });
 


### PR DESCRIPTION
The `Metadata` and `Enumerable` extensions are defined in the EIPs, so their interfaces should be included in `interfaces/`.