### PR TITLE
Use custom errors in `AddressUtils`

### DIFF
--- a/contracts/token/non_fungible/_NonFungibleToken.sol
+++ b/contracts/token/non_fungible/_NonFungibleToken.sol
@@ -240,7 +240,7 @@ abstract contract _NonFungibleToken is _INonFungibleToken, _Introspectable {
                 tokenId,
                 data
             ),
-            'NonFungibleToken: transfer to non ERC721Receiver implementer'
+            NonFungibleToken__ERC721ReceiverNotImplemented.selector
         );
 
         bytes4 returnValue = abi.decode(returnData, (bytes4));

--- a/contracts/utils/AddressUtils.sol
+++ b/contracts/utils/AddressUtils.sol
@@ -13,12 +13,6 @@ library AddressUtils {
     error AddressUtils__FailedCall();
     error AddressUtils__FailedCallWithValue();
 
-    // TODO: without this function, custom errors referenced by selector are not available in tests
-    function __placeholder() internal {
-        revert AddressUtils__FailedCall();
-        revert AddressUtils__FailedCallWithValue();
-    }
-
     function toString(address account) internal pure returns (string memory) {
         return uint256(uint160(account)).toHexString(20);
     }

--- a/contracts/utils/SafeERC20.sol
+++ b/contracts/utils/SafeERC20.sol
@@ -91,7 +91,7 @@ library SafeERC20 {
     function _callOptionalReturn(IERC20 token, bytes memory data) private {
         bytes memory returndata = address(token).functionCall(
             data,
-            'SafeERC20: low-level call failed'
+            SafeERC20__OperationFailed.selector
         );
 
         if (returndata.length > 0) {

--- a/spec/token/non_fungible/NonFungibleToken.behavior.ts
+++ b/spec/token/non_fungible/NonFungibleToken.behavior.ts
@@ -378,8 +378,9 @@ export function describeBehaviorOfNonFungibleToken(
               [
                 'safeTransferFrom(address,address,uint256)'
               ](holder.address, await instance.getAddress(), tokenId),
-          ).to.be.revertedWith(
-            'NonFungibleToken: transfer to non ERC721Receiver implementer',
+          ).to.be.revertedWithCustomError(
+            instance,
+            'NonFungibleToken__ERC721ReceiverNotImplemented',
           );
         });
 
@@ -510,8 +511,9 @@ export function describeBehaviorOfNonFungibleToken(
               [
                 'safeTransferFrom(address,address,uint256,bytes)'
               ](holder.address, await instance.getAddress(), tokenId, '0x'),
-          ).to.be.revertedWith(
-            'NonFungibleToken: transfer to non ERC721Receiver implementer',
+          ).to.be.revertedWithCustomError(
+            instance,
+            'NonFungibleToken__ERC721ReceiverNotImplemented',
           );
         });
 

--- a/test/token/non_fungible/NonFungibleToken.ts
+++ b/test/token/non_fungible/NonFungibleToken.ts
@@ -245,8 +245,9 @@ describe('NonFungibleToken', () => {
               await instance.getAddress(),
               2,
             ),
-          ).to.be.revertedWith(
-            'NonFungibleToken: transfer to non ERC721Receiver implementer',
+          ).to.be.revertedWithCustomError(
+            instance,
+            'NonFungibleToken__ERC721ReceiverNotImplemented',
           );
         });
 
@@ -368,8 +369,9 @@ describe('NonFungibleToken', () => {
               2,
               '0x',
             ),
-          ).to.be.revertedWith(
-            'NonFungibleToken: transfer to non ERC721Receiver implementer',
+          ).to.be.revertedWithCustomError(
+            instance,
+            'NonFungibleToken__ERC721ReceiverNotImplemented',
           );
         });
 
@@ -594,8 +596,9 @@ describe('NonFungibleToken', () => {
               tokenId,
               '0x',
             ),
-          ).to.be.revertedWith(
-            'NonFungibleToken: transfer to non ERC721Receiver implementer',
+          ).to.be.revertedWithCustomError(
+            instance,
+            'NonFungibleToken__ERC721ReceiverNotImplemented',
           );
         });
 
@@ -685,8 +688,9 @@ describe('NonFungibleToken', () => {
               0,
               '0x',
             ),
-          ).to.be.revertedWith(
-            'NonFungibleToken: transfer to non ERC721Receiver implementer',
+          ).to.be.revertedWithCustomError(
+            instance,
+            'NonFungibleToken__ERC721ReceiverNotImplemented',
           );
         });
       });

--- a/test/utils/AddressUtils.ts
+++ b/test/utils/AddressUtils.ts
@@ -15,6 +15,10 @@ describe('AddressUtils', async () => {
   let instance: $AddressUtils;
   let deployer: SignerWithAddress;
 
+  // the custom errors are not available on the $AddressUtils ABI
+  // a placeholder interface is needed in order to expose them to revertedWithCustomError matcher
+  const placeholder = { interface: AddressUtils__factory.createInterface() };
+
   beforeEach(async () => {
     [deployer] = await ethers.getSigners();
     instance = await new $AddressUtils__factory(deployer).deploy();
@@ -137,7 +141,10 @@ describe('AddressUtils', async () => {
               [
                 '$functionCall(address,bytes)'
               ](await targetContract.getAddress(), '0x'),
-          ).to.be.revertedWithCustomError(instance, 'AddressUtils__FailedCall');
+          ).to.be.revertedWithCustomError(
+            placeholder,
+            'AddressUtils__FailedCall',
+          );
         });
       });
     });
@@ -204,7 +211,7 @@ describe('AddressUtils', async () => {
           // unrelated custom error, but it must exist on the contract due to limitiations with revertedWithCustomError matcher
           const customError = 'AddressUtils__InsufficientBalance';
           const revertReason =
-            instance.interface.getError(customError)?.selector!;
+            placeholder.interface.getError(customError)?.selector!;
 
           const targetContract = await new AddressUtils__factory(
             deployer,
@@ -317,7 +324,7 @@ describe('AddressUtils', async () => {
                 '$functionCallWithValue(address,bytes,uint256)'
               ](await targetContract.getAddress(), data, value),
           ).to.be.revertedWithCustomError(
-            instance,
+            placeholder,
             'AddressUtils__FailedCallWithValue',
           );
         });
@@ -357,7 +364,7 @@ describe('AddressUtils', async () => {
                 '$functionCallWithValue(address,bytes,uint256)'
               ](await targetContract.getAddress(), '0x', 0),
           ).to.be.revertedWithCustomError(
-            instance,
+            placeholder,
             'AddressUtils__FailedCallWithValue',
           );
         });
@@ -444,7 +451,7 @@ describe('AddressUtils', async () => {
           // unrelated custom error, but it must exist on the contract due to limitiations with revertedWithCustomError matcher
           const customError = 'AddressUtils__InsufficientBalance';
           const revertReason =
-            instance.interface.getError(customError)?.selector!;
+            placeholder.interface.getError(customError)?.selector!;
 
           await setBalance(await instance.getAddress(), value);
 
@@ -495,7 +502,7 @@ describe('AddressUtils', async () => {
           // unrelated custom error, but it must exist on the contract due to limitiations with revertedWithCustomError matcher
           const customError = 'AddressUtils__InsufficientBalance';
           const revertReason =
-            instance.interface.getError(customError)?.selector!;
+            placeholder.interface.getError(customError)?.selector!;
 
           const targetContract = await new AddressUtils__factory(
             deployer,


### PR DESCRIPTION
This significantly reduces the size of contracts that use the `AddressUtils` functions.  In particular, `Proxy` in #226.