### PR TITLE
Remove deprecated keywords ahead of solidity `0.9.0`

### DIFF
--- a/contracts/access/access_control/_AccessControl.sol
+++ b/contracts/access/access_control/_AccessControl.sol
@@ -162,7 +162,7 @@ abstract contract _AccessControl is _IAccessControl, _Context {
                 .layout(AccessControlStorage.DEFAULT_STORAGE_SLOT)
                 .roles[role]
                 .members
-                .at(index);
+                .valueAt(index);
     }
 
     /**

--- a/contracts/access/access_control/_AccessControl.sol
+++ b/contracts/access/access_control/_AccessControl.sol
@@ -40,7 +40,7 @@ abstract contract _AccessControl is _IAccessControl, _Context {
     ) internal view virtual returns (bool status) {
         return
             AccessControlStorage
-                .layout(AccessControlStorage.DEFAULT_STORAGE_SLOT)
+                .ref(AccessControlStorage.DEFAULT_STORAGE_SLOT)
                 .roles[role]
                 .members
                 .contains(account);
@@ -75,7 +75,7 @@ abstract contract _AccessControl is _IAccessControl, _Context {
     ) internal view virtual returns (bytes32) {
         return
             AccessControlStorage
-                .layout(AccessControlStorage.DEFAULT_STORAGE_SLOT)
+                .ref(AccessControlStorage.DEFAULT_STORAGE_SLOT)
                 .roles[role]
                 .adminRole;
     }
@@ -88,7 +88,7 @@ abstract contract _AccessControl is _IAccessControl, _Context {
     function _setRoleAdmin(bytes32 role, bytes32 adminRole) internal virtual {
         bytes32 previousAdminRole = _getRoleAdmin(role);
         AccessControlStorage
-            .layout(AccessControlStorage.DEFAULT_STORAGE_SLOT)
+            .ref(AccessControlStorage.DEFAULT_STORAGE_SLOT)
             .roles[role]
             .adminRole = adminRole;
         emit RoleAdminChanged(role, previousAdminRole, adminRole);
@@ -133,14 +133,14 @@ abstract contract _AccessControl is _IAccessControl, _Context {
     ) internal virtual {
         if (status) {
             AccessControlStorage
-                .layout(AccessControlStorage.DEFAULT_STORAGE_SLOT)
+                .ref(AccessControlStorage.DEFAULT_STORAGE_SLOT)
                 .roles[role]
                 .members
                 .add(account);
             emit RoleGranted(role, account, _msgSender());
         } else {
             AccessControlStorage
-                .layout(AccessControlStorage.DEFAULT_STORAGE_SLOT)
+                .ref(AccessControlStorage.DEFAULT_STORAGE_SLOT)
                 .roles[role]
                 .members
                 .remove(account);
@@ -159,7 +159,7 @@ abstract contract _AccessControl is _IAccessControl, _Context {
     ) internal view virtual returns (address) {
         return
             AccessControlStorage
-                .layout(AccessControlStorage.DEFAULT_STORAGE_SLOT)
+                .ref(AccessControlStorage.DEFAULT_STORAGE_SLOT)
                 .roles[role]
                 .members
                 .valueAt(index);
@@ -174,7 +174,7 @@ abstract contract _AccessControl is _IAccessControl, _Context {
     ) internal view virtual returns (uint256) {
         return
             AccessControlStorage
-                .layout(AccessControlStorage.DEFAULT_STORAGE_SLOT)
+                .ref(AccessControlStorage.DEFAULT_STORAGE_SLOT)
                 .roles[role]
                 .members
                 .length();

--- a/contracts/access/initializable/_Initializable.sol
+++ b/contracts/access/initializable/_Initializable.sol
@@ -21,7 +21,7 @@ abstract contract _Initializable is _IInitializable {
     }
 
     function _setInitializedVersion(uint8 version) internal virtual {
-        InitializableStorage.Layout storage $ = InitializableStorage.layout(
+        InitializableStorage.Layout storage $ = InitializableStorage.ref(
             InitializableStorage.DEFAULT_STORAGE_SLOT
         );
 
@@ -39,7 +39,7 @@ abstract contract _Initializable is _IInitializable {
         returns (uint8 version)
     {
         version = InitializableStorage
-            .layout(InitializableStorage.DEFAULT_STORAGE_SLOT)
+            .ref(InitializableStorage.DEFAULT_STORAGE_SLOT)
             .initialized;
     }
 }

--- a/contracts/access/ownable/_Ownable.sol
+++ b/contracts/access/ownable/_Ownable.sol
@@ -23,7 +23,7 @@ abstract contract _Ownable is _IOwnable, _Context {
     }
 
     function _owner() internal view virtual returns (address) {
-        return ERC173Storage.layout(ERC173Storage.DEFAULT_STORAGE_SLOT).owner;
+        return ERC173Storage.ref(ERC173Storage.DEFAULT_STORAGE_SLOT).owner;
     }
 
     function _transitiveOwner() internal view virtual returns (address owner) {
@@ -43,7 +43,7 @@ abstract contract _Ownable is _IOwnable, _Context {
     }
 
     function _setOwner(address account) internal virtual {
-        ERC173Storage.Layout storage $ = ERC173Storage.layout(
+        ERC173Storage.Layout storage $ = ERC173Storage.ref(
             ERC173Storage.DEFAULT_STORAGE_SLOT
         );
         emit OwnershipTransferred($.owner, account);

--- a/contracts/access/ownable/safe/_SafeOwnable.sol
+++ b/contracts/access/ownable/safe/_SafeOwnable.sol
@@ -21,7 +21,7 @@ abstract contract _SafeOwnable is _ISafeOwnable, _Ownable {
     function _nomineeOwner() internal view virtual returns (address) {
         return
             ERC173Storage
-                .layout(ERC173Storage.DEFAULT_STORAGE_SLOT)
+                .ref(ERC173Storage.DEFAULT_STORAGE_SLOT)
                 .nomineeOwner;
     }
 
@@ -36,7 +36,7 @@ abstract contract _SafeOwnable is _ISafeOwnable, _Ownable {
         returns (duration transferTimelockDuration)
     {
         transferTimelockDuration = ERC173Storage
-            .layout(ERC173Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC173Storage.DEFAULT_STORAGE_SLOT)
             .transferTimelockDuration;
     }
 
@@ -44,7 +44,7 @@ abstract contract _SafeOwnable is _ISafeOwnable, _Ownable {
      * @notice accept transfer of contract ownership
      */
     function _acceptOwnership() internal virtual onlyNomineeOwner {
-        ERC173Storage.Layout storage $ = ERC173Storage.layout(
+        ERC173Storage.Layout storage $ = ERC173Storage.ref(
             ERC173Storage.DEFAULT_STORAGE_SLOT
         );
 
@@ -75,7 +75,7 @@ abstract contract _SafeOwnable is _ISafeOwnable, _Ownable {
      */
     function _setNomineeOwner(address account) internal virtual {
         ERC173Storage
-            .layout(ERC173Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC173Storage.DEFAULT_STORAGE_SLOT)
             .nomineeOwner = account;
     }
 
@@ -90,7 +90,7 @@ abstract contract _SafeOwnable is _ISafeOwnable, _Ownable {
         transferTimelock = Timelock.create(_getTransferTimelockDuration());
 
         ERC173Storage
-            .layout(ERC173Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC173Storage.DEFAULT_STORAGE_SLOT)
             .transferTimelock = transferTimelock;
     }
 
@@ -102,7 +102,7 @@ abstract contract _SafeOwnable is _ISafeOwnable, _Ownable {
         duration transferTimelockDuration
     ) internal virtual {
         ERC173Storage
-            .layout(ERC173Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC173Storage.DEFAULT_STORAGE_SLOT)
             .transferTimelockDuration = transferTimelockDuration;
     }
 }

--- a/contracts/access/partially_pausable/_PartiallyPausable.sol
+++ b/contracts/access/partially_pausable/_PartiallyPausable.sol
@@ -29,7 +29,7 @@ abstract contract _PartiallyPausable is _IPartiallyPausable, _Context {
         bytes32 key
     ) internal view virtual returns (bool status) {
         status = PausableStorage
-            .layout(PausableStorage.DEFAULT_STORAGE_SLOT)
+            .ref(PausableStorage.DEFAULT_STORAGE_SLOT)
             .partiallyPaused[key];
     }
 
@@ -41,7 +41,7 @@ abstract contract _PartiallyPausable is _IPartiallyPausable, _Context {
         bytes32 key
     ) internal virtual whenNotPartiallyPaused(key) {
         PausableStorage
-            .layout(PausableStorage.DEFAULT_STORAGE_SLOT)
+            .ref(PausableStorage.DEFAULT_STORAGE_SLOT)
             .partiallyPaused[key] = true;
         emit PartiallyPaused(_msgSender(), key);
     }
@@ -54,7 +54,7 @@ abstract contract _PartiallyPausable is _IPartiallyPausable, _Context {
         bytes32 key
     ) internal virtual whenPartiallyPaused(key) {
         delete PausableStorage
-            .layout(PausableStorage.DEFAULT_STORAGE_SLOT)
+            .ref(PausableStorage.DEFAULT_STORAGE_SLOT)
             .partiallyPaused[key];
         emit PartiallyUnpaused(_msgSender(), key);
     }

--- a/contracts/access/pausable/_Pausable.sol
+++ b/contracts/access/pausable/_Pausable.sol
@@ -26,7 +26,7 @@ abstract contract _Pausable is _IPausable, _Context {
      */
     function _paused() internal view virtual returns (bool status) {
         status = PausableStorage
-            .layout(PausableStorage.DEFAULT_STORAGE_SLOT)
+            .ref(PausableStorage.DEFAULT_STORAGE_SLOT)
             .paused;
     }
 
@@ -35,7 +35,7 @@ abstract contract _Pausable is _IPausable, _Context {
      */
     function _pause() internal virtual whenNotPaused {
         PausableStorage
-            .layout(PausableStorage.DEFAULT_STORAGE_SLOT)
+            .ref(PausableStorage.DEFAULT_STORAGE_SLOT)
             .paused = true;
         emit Paused(_msgSender());
     }
@@ -45,7 +45,7 @@ abstract contract _Pausable is _IPausable, _Context {
      */
     function _unpause() internal virtual whenPaused {
         delete PausableStorage
-            .layout(PausableStorage.DEFAULT_STORAGE_SLOT)
+            .ref(PausableStorage.DEFAULT_STORAGE_SLOT)
             .paused;
         emit Unpaused(_msgSender());
     }

--- a/contracts/access/reentrancy_guard/_ReentrancyGuard.sol
+++ b/contracts/access/reentrancy_guard/_ReentrancyGuard.sol
@@ -9,7 +9,7 @@ abstract contract _ReentrancyGuard is _IReentrancyGuard {
     uint256 internal constant REENTRANCY_STATUS_LOCKED = 2;
     uint256 internal constant REENTRANCY_STATUS_UNLOCKED = 1;
 
-    modifier nonReentrant() virtual {
+    modifier nonReentrant() {
         if (_isReentrancyGuardLocked()) revert ReentrancyGuard__ReentrantCall();
         _lockReentrancyGuard();
         _;

--- a/contracts/access/reentrancy_guard/_ReentrancyGuard.sol
+++ b/contracts/access/reentrancy_guard/_ReentrancyGuard.sol
@@ -22,7 +22,7 @@ abstract contract _ReentrancyGuard is _IReentrancyGuard {
     function _isReentrancyGuardLocked() internal view virtual returns (bool) {
         return
             ReentrancyGuardStorage
-                .layout(ReentrancyGuardStorage.DEFAULT_STORAGE_SLOT)
+                .ref(ReentrancyGuardStorage.DEFAULT_STORAGE_SLOT)
                 .status == REENTRANCY_STATUS_LOCKED;
     }
 
@@ -31,7 +31,7 @@ abstract contract _ReentrancyGuard is _IReentrancyGuard {
      */
     function _lockReentrancyGuard() internal virtual {
         ReentrancyGuardStorage
-            .layout(ReentrancyGuardStorage.DEFAULT_STORAGE_SLOT)
+            .ref(ReentrancyGuardStorage.DEFAULT_STORAGE_SLOT)
             .status = REENTRANCY_STATUS_LOCKED;
     }
 
@@ -40,7 +40,7 @@ abstract contract _ReentrancyGuard is _IReentrancyGuard {
      */
     function _unlockReentrancyGuard() internal virtual {
         ReentrancyGuardStorage
-            .layout(ReentrancyGuardStorage.DEFAULT_STORAGE_SLOT)
+            .ref(ReentrancyGuardStorage.DEFAULT_STORAGE_SLOT)
             .status = REENTRANCY_STATUS_UNLOCKED;
     }
 }

--- a/contracts/beacon/_Beacon.sol
+++ b/contracts/beacon/_Beacon.sol
@@ -18,7 +18,7 @@ abstract contract _Beacon is _IBeacon, _Ownable {
         returns (address implementation)
     {
         implementation = BeaconStorage
-            .layout(BeaconStorage.DEFAULT_STORAGE_SLOT)
+            .ref(BeaconStorage.DEFAULT_STORAGE_SLOT)
             .implementation;
     }
 
@@ -30,7 +30,7 @@ abstract contract _Beacon is _IBeacon, _Ownable {
         address implementation
     ) internal virtual onlyOwner {
         BeaconStorage
-            .layout(BeaconStorage.DEFAULT_STORAGE_SLOT)
+            .ref(BeaconStorage.DEFAULT_STORAGE_SLOT)
             .implementation = implementation;
     }
 }

--- a/contracts/data/EnumerableMap.sol
+++ b/contracts/data/EnumerableMap.sol
@@ -31,21 +31,21 @@ library EnumerableMap {
         Map _inner;
     }
 
-    function at(
+    function valueAt(
         AddressToAddressMap storage map,
         uint256 index
     ) internal view returns (address key, address value) {
-        (bytes32 keyBytes, bytes32 valueBytes) = _at(map._inner, index);
+        (bytes32 keyBytes, bytes32 valueBytes) = _valueAt(map._inner, index);
 
         key = address(uint160(uint256(keyBytes)));
         value = address(uint160(uint256(valueBytes)));
     }
 
-    function at(
+    function valueAt(
         UintToAddressMap storage map,
         uint256 index
     ) internal view returns (uint256 key, address value) {
-        (bytes32 keyBytes, bytes32 valueBytes) = _at(map._inner, index);
+        (bytes32 keyBytes, bytes32 valueBytes) = _valueAt(map._inner, index);
 
         key = uint256(keyBytes);
         value = address(uint160(uint256(valueBytes)));
@@ -291,7 +291,7 @@ library EnumerableMap {
         }
     }
 
-    function _at(
+    function _valueAt(
         Map storage map,
         uint256 index
     ) private view returns (bytes32 key, bytes32 value) {

--- a/contracts/data/EnumerableSet.sol
+++ b/contracts/data/EnumerableSet.sol
@@ -32,25 +32,25 @@ library EnumerableSet {
         Set _inner;
     }
 
-    function at(
+    function valueAt(
         Bytes32Set storage set,
         uint256 index
     ) internal view returns (bytes32) {
-        return _at(set._inner, index);
+        return _valueAt(set._inner, index);
     }
 
-    function at(
+    function valueAt(
         AddressSet storage set,
         uint256 index
     ) internal view returns (address) {
-        return address(uint160(uint256(_at(set._inner, index))));
+        return address(uint160(uint256(_valueAt(set._inner, index))));
     }
 
-    function at(
+    function valueAt(
         UintSet storage set,
         uint256 index
     ) internal view returns (uint256) {
-        return uint256(_at(set._inner, index));
+        return uint256(_valueAt(set._inner, index));
     }
 
     function contains(
@@ -196,7 +196,7 @@ library EnumerableSet {
         }
     }
 
-    function _at(
+    function _valueAt(
         Set storage set,
         uint256 index
     ) private view returns (bytes32) {

--- a/contracts/data/MerkleTree.sol
+++ b/contracts/data/MerkleTree.sol
@@ -51,7 +51,7 @@ library MerkleTree {
      */
     function root(Tree storage self) internal view returns (bytes32 rootHash) {
         unchecked {
-            rootHash = _at(
+            rootHash = _valueAt(
                 _arraySlot(self),
                 ~(type(uint256).max << self.height())
             );
@@ -64,7 +64,7 @@ library MerkleTree {
      * @param index leaf node index to query
      * @return element element stored at index
      */
-    function at(
+    function valueAt(
         Tree storage self,
         uint256 index
     ) internal view returns (bytes32 element) {
@@ -75,7 +75,7 @@ library MerkleTree {
             Panic.panic(Panic.ARRAY_ACCESS_OUT_OF_BOUNDS);
         }
 
-        element = _at(_arraySlot(self), index);
+        element = _valueAt(_arraySlot(self), index);
     }
 
     /**
@@ -128,7 +128,7 @@ library MerkleTree {
 
         // recalculate branch and root nodes
         // TODO: this involves an unnecessary storage write at depth 0
-        _set(slot, 0, index, index, _at(slot, index));
+        _set(slot, 0, index, index, _valueAt(slot, index));
     }
 
     /**
@@ -171,7 +171,7 @@ library MerkleTree {
      * @param index index to query
      * @return element element stored at index
      */
-    function _at(
+    function _valueAt(
         bytes32 arraySlot,
         uint256 index
     ) private view returns (bytes32 element) {

--- a/contracts/introspection/_Introspectable.sol
+++ b/contracts/introspection/_Introspectable.sol
@@ -19,7 +19,7 @@ abstract contract _Introspectable is _IIntrospectable {
     ) internal view virtual returns (bool) {
         return
             ERC165Storage
-                .layout(ERC165Storage.DEFAULT_STORAGE_SLOT)
+                .ref(ERC165Storage.DEFAULT_STORAGE_SLOT)
                 .supportedInterfaces[interfaceId];
     }
 
@@ -35,7 +35,7 @@ abstract contract _Introspectable is _IIntrospectable {
         if (interfaceId == 0xffffffff)
             revert Introspectable__InvalidInterfaceId();
         ERC165Storage
-            .layout(ERC165Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC165Storage.DEFAULT_STORAGE_SLOT)
             .supportedInterfaces[interfaceId] = status;
     }
 }

--- a/contracts/meta/_ForwardedMetaTransactionContext.sol
+++ b/contracts/meta/_ForwardedMetaTransactionContext.sol
@@ -89,7 +89,7 @@ abstract contract _ForwardedMetaTransactionContext is
         address account
     ) internal view virtual returns (bool trustedStatus) {
         trustedStatus = ERC2771Storage
-            .layout(ERC2771Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC2771Storage.DEFAULT_STORAGE_SLOT)
             .trustedForwarders[account];
     }
 
@@ -99,7 +99,7 @@ abstract contract _ForwardedMetaTransactionContext is
      */
     function _addTrustedForwarder(address account) internal virtual {
         ERC2771Storage
-            .layout(ERC2771Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC2771Storage.DEFAULT_STORAGE_SLOT)
             .trustedForwarders[account] = true;
     }
 
@@ -109,7 +109,7 @@ abstract contract _ForwardedMetaTransactionContext is
      */
     function _removeTrustedForwarder(address account) internal virtual {
         delete ERC2771Storage
-            .layout(ERC2771Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC2771Storage.DEFAULT_STORAGE_SLOT)
             .trustedForwarders[account];
     }
 }

--- a/contracts/proxy/diamond/_DiamondProxy.sol
+++ b/contracts/proxy/diamond/_DiamondProxy.sol
@@ -40,7 +40,7 @@ abstract contract _DiamondProxy is _IDiamondProxy, _Proxy {
         facet = address(
             bytes20(
                 ERC2535Storage
-                    .layout(ERC2535Storage.DEFAULT_STORAGE_SLOT)
+                    .ref(ERC2535Storage.DEFAULT_STORAGE_SLOT)
                     .selectorInfo[selector]
             )
         );
@@ -57,7 +57,7 @@ abstract contract _DiamondProxy is _IDiamondProxy, _Proxy {
         address target,
         bytes memory data
     ) internal virtual {
-        ERC2535Storage.Layout storage $ = ERC2535Storage.layout(
+        ERC2535Storage.Layout storage $ = ERC2535Storage.ref(
             ERC2535Storage.DEFAULT_STORAGE_SLOT
         );
 

--- a/contracts/proxy/diamond/fallback/_DiamondProxyFallback.sol
+++ b/contracts/proxy/diamond/fallback/_DiamondProxyFallback.sol
@@ -39,7 +39,7 @@ abstract contract _DiamondProxyFallback is
         returns (address fallbackAddress)
     {
         fallbackAddress = ERC2535Storage
-            .layout(ERC2535Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC2535Storage.DEFAULT_STORAGE_SLOT)
             .fallbackAddress;
     }
 
@@ -58,7 +58,7 @@ abstract contract _DiamondProxyFallback is
      */
     function _setFallbackAddress(address fallbackAddress) internal virtual {
         ERC2535Storage
-            .layout(ERC2535Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC2535Storage.DEFAULT_STORAGE_SLOT)
             .fallbackAddress = fallbackAddress;
     }
 }

--- a/contracts/proxy/diamond/readable/_DiamondProxyReadable.sol
+++ b/contracts/proxy/diamond/readable/_DiamondProxyReadable.sol
@@ -21,7 +21,7 @@ abstract contract _DiamondProxyReadable is
      * @return diamondFacets array of structured facet data
      */
     function _facets() internal view returns (Facet[] memory diamondFacets) {
-        ERC2535Storage.Layout storage $ = ERC2535Storage.layout(
+        ERC2535Storage.Layout storage $ = ERC2535Storage.ref(
             ERC2535Storage.DEFAULT_STORAGE_SLOT
         );
 
@@ -103,7 +103,7 @@ abstract contract _DiamondProxyReadable is
     function _facetFunctionSelectors(
         address facet
     ) internal view returns (bytes4[] memory selectors) {
-        ERC2535Storage.Layout storage $ = ERC2535Storage.layout(
+        ERC2535Storage.Layout storage $ = ERC2535Storage.ref(
             ERC2535Storage.DEFAULT_STORAGE_SLOT
         );
 
@@ -153,7 +153,7 @@ abstract contract _DiamondProxyReadable is
         view
         returns (address[] memory addresses)
     {
-        ERC2535Storage.Layout storage $ = ERC2535Storage.layout(
+        ERC2535Storage.Layout storage $ = ERC2535Storage.ref(
             ERC2535Storage.DEFAULT_STORAGE_SLOT
         );
 

--- a/contracts/signature/contract_signer/_ContractSigner.sol
+++ b/contracts/signature/contract_signer/_ContractSigner.sol
@@ -25,7 +25,7 @@ abstract contract _ContractSigner is _IContractSigner {
         signature;
 
         return
-            ERC1271Storage.layout(ERC1271Storage.DEFAULT_STORAGE_SLOT).hashes[
+            ERC1271Storage.ref(ERC1271Storage.DEFAULT_STORAGE_SLOT).hashes[
                 hash
             ]
                 ? MAGIC_VALUE
@@ -33,7 +33,7 @@ abstract contract _ContractSigner is _IContractSigner {
     }
 
     function _setValidSignature(bytes32 hash, bool status) internal virtual {
-        ERC1271Storage.layout(ERC1271Storage.DEFAULT_STORAGE_SLOT).hashes[
+        ERC1271Storage.ref(ERC1271Storage.DEFAULT_STORAGE_SLOT).hashes[
             hash
         ] = status;
     }

--- a/contracts/storage/AccessControlStorage.sol
+++ b/contracts/storage/AccessControlStorage.sol
@@ -29,11 +29,11 @@ library AccessControlStorage {
             ) & ~bytes32(uint256(0xff))
         );
 
-    function layout() internal pure returns (Layout storage $) {
-        $ = layout(DEFAULT_STORAGE_SLOT);
+    function ref() internal pure returns (Layout storage $) {
+        $ = ref(DEFAULT_STORAGE_SLOT);
     }
 
-    function layout(sslot slot) internal pure returns (Layout storage $) {
+    function ref(sslot slot) internal pure returns (Layout storage $) {
         assembly {
             $.slot := slot
         }

--- a/contracts/storage/BeaconStorage.sol
+++ b/contracts/storage/BeaconStorage.sol
@@ -21,11 +21,11 @@ library BeaconStorage {
             ) & ~bytes32(uint256(0xff))
         );
 
-    function layout() internal pure returns (Layout storage $) {
-        $ = layout(DEFAULT_STORAGE_SLOT);
+    function ref() internal pure returns (Layout storage $) {
+        $ = ref(DEFAULT_STORAGE_SLOT);
     }
 
-    function layout(sslot slot) internal pure returns (Layout storage $) {
+    function ref(sslot slot) internal pure returns (Layout storage $) {
         assembly {
             $.slot := slot
         }

--- a/contracts/storage/ERC1155Storage.sol
+++ b/contracts/storage/ERC1155Storage.sol
@@ -28,11 +28,11 @@ library ERC1155Storage {
             ) & ~bytes32(uint256(0xff))
         );
 
-    function layout() internal pure returns (Layout storage $) {
-        $ = layout(DEFAULT_STORAGE_SLOT);
+    function ref() internal pure returns (Layout storage $) {
+        $ = ref(DEFAULT_STORAGE_SLOT);
     }
 
-    function layout(sslot slot) internal pure returns (Layout storage $) {
+    function ref(sslot slot) internal pure returns (Layout storage $) {
         assembly {
             $.slot := slot
         }

--- a/contracts/storage/ERC1271Storage.sol
+++ b/contracts/storage/ERC1271Storage.sol
@@ -21,11 +21,11 @@ library ERC1271Storage {
             ) & ~bytes32(uint256(0xff))
         );
 
-    function layout() internal pure returns (Layout storage $) {
-        $ = layout(DEFAULT_STORAGE_SLOT);
+    function ref() internal pure returns (Layout storage $) {
+        $ = ref(DEFAULT_STORAGE_SLOT);
     }
 
-    function layout(sslot slot) internal pure returns (Layout storage $) {
+    function ref(sslot slot) internal pure returns (Layout storage $) {
         assembly {
             $.slot := slot
         }

--- a/contracts/storage/ERC165Storage.sol
+++ b/contracts/storage/ERC165Storage.sol
@@ -21,11 +21,11 @@ library ERC165Storage {
             ) & ~bytes32(uint256(0xff))
         );
 
-    function layout() internal pure returns (Layout storage $) {
-        $ = layout(DEFAULT_STORAGE_SLOT);
+    function ref() internal pure returns (Layout storage $) {
+        $ = ref(DEFAULT_STORAGE_SLOT);
     }
 
-    function layout(sslot slot) internal pure returns (Layout storage $) {
+    function ref(sslot slot) internal pure returns (Layout storage $) {
         assembly {
             $.slot := slot
         }

--- a/contracts/storage/ERC173Storage.sol
+++ b/contracts/storage/ERC173Storage.sol
@@ -26,11 +26,11 @@ library ERC173Storage {
             ) & ~bytes32(uint256(0xff))
         );
 
-    function layout() internal pure returns (Layout storage $) {
-        $ = layout(DEFAULT_STORAGE_SLOT);
+    function ref() internal pure returns (Layout storage $) {
+        $ = ref(DEFAULT_STORAGE_SLOT);
     }
 
-    function layout(sslot slot) internal pure returns (Layout storage $) {
+    function ref(sslot slot) internal pure returns (Layout storage $) {
         assembly {
             $.slot := slot
         }

--- a/contracts/storage/ERC20Storage.sol
+++ b/contracts/storage/ERC20Storage.sol
@@ -37,11 +37,11 @@ library ERC20Storage {
             ) & ~bytes32(uint256(0xff))
         );
 
-    function layout() internal pure returns (Layout storage $) {
-        $ = layout(DEFAULT_STORAGE_SLOT);
+    function ref() internal pure returns (Layout storage $) {
+        $ = ref(DEFAULT_STORAGE_SLOT);
     }
 
-    function layout(sslot slot) internal pure returns (Layout storage $) {
+    function ref(sslot slot) internal pure returns (Layout storage $) {
         assembly {
             $.slot := slot
         }

--- a/contracts/storage/ERC2535Storage.sol
+++ b/contracts/storage/ERC2535Storage.sol
@@ -27,11 +27,11 @@ library ERC2535Storage {
             ) & ~bytes32(uint256(0xff))
         );
 
-    function layout() internal pure returns (Layout storage $) {
-        $ = layout(DEFAULT_STORAGE_SLOT);
+    function ref() internal pure returns (Layout storage $) {
+        $ = ref(DEFAULT_STORAGE_SLOT);
     }
 
-    function layout(sslot slot) internal pure returns (Layout storage $) {
+    function ref(sslot slot) internal pure returns (Layout storage $) {
         assembly {
             $.slot := slot
         }

--- a/contracts/storage/ERC2771Storage.sol
+++ b/contracts/storage/ERC2771Storage.sol
@@ -21,11 +21,11 @@ library ERC2771Storage {
             ) & ~bytes32(uint256(0xff))
         );
 
-    function layout() internal pure returns (Layout storage $) {
-        $ = layout(DEFAULT_STORAGE_SLOT);
+    function ref() internal pure returns (Layout storage $) {
+        $ = ref(DEFAULT_STORAGE_SLOT);
     }
 
-    function layout(sslot slot) internal pure returns (Layout storage $) {
+    function ref(sslot slot) internal pure returns (Layout storage $) {
         assembly {
             $.slot := slot
         }

--- a/contracts/storage/ERC2981Storage.sol
+++ b/contracts/storage/ERC2981Storage.sol
@@ -24,11 +24,11 @@ library ERC2981Storage {
             ) & ~bytes32(uint256(0xff))
         );
 
-    function layout() internal pure returns (Layout storage $) {
-        $ = layout(DEFAULT_STORAGE_SLOT);
+    function ref() internal pure returns (Layout storage $) {
+        $ = ref(DEFAULT_STORAGE_SLOT);
     }
 
-    function layout(sslot slot) internal pure returns (Layout storage $) {
+    function ref(sslot slot) internal pure returns (Layout storage $) {
         assembly {
             $.slot := slot
         }

--- a/contracts/storage/ERC721Storage.sol
+++ b/contracts/storage/ERC721Storage.sol
@@ -30,11 +30,11 @@ library ERC721Storage {
             ) & ~bytes32(uint256(0xff))
         );
 
-    function layout() internal pure returns (Layout storage $) {
-        $ = layout(DEFAULT_STORAGE_SLOT);
+    function ref() internal pure returns (Layout storage $) {
+        $ = ref(DEFAULT_STORAGE_SLOT);
     }
 
-    function layout(sslot slot) internal pure returns (Layout storage $) {
+    function ref(sslot slot) internal pure returns (Layout storage $) {
         assembly {
             $.slot := slot
         }

--- a/contracts/storage/InitializableStorage.sol
+++ b/contracts/storage/InitializableStorage.sol
@@ -23,11 +23,11 @@ library InitializableStorage {
             ) & ~bytes32(uint256(0xff))
         );
 
-    function layout() internal pure returns (Layout storage $) {
-        $ = layout(DEFAULT_STORAGE_SLOT);
+    function ref() internal pure returns (Layout storage $) {
+        $ = ref(DEFAULT_STORAGE_SLOT);
     }
 
-    function layout(sslot slot) internal pure returns (Layout storage $) {
+    function ref(sslot slot) internal pure returns (Layout storage $) {
         assembly {
             $.slot := slot
         }

--- a/contracts/storage/PausableStorage.sol
+++ b/contracts/storage/PausableStorage.sol
@@ -22,11 +22,11 @@ library PausableStorage {
             ) & ~bytes32(uint256(0xff))
         );
 
-    function layout() internal pure returns (Layout storage $) {
-        $ = layout(DEFAULT_STORAGE_SLOT);
+    function ref() internal pure returns (Layout storage $) {
+        $ = ref(DEFAULT_STORAGE_SLOT);
     }
 
-    function layout(sslot slot) internal pure returns (Layout storage $) {
+    function ref(sslot slot) internal pure returns (Layout storage $) {
         assembly {
             $.slot := slot
         }

--- a/contracts/storage/ReentrancyGuardStorage.sol
+++ b/contracts/storage/ReentrancyGuardStorage.sol
@@ -23,11 +23,11 @@ library ReentrancyGuardStorage {
             ) & ~bytes32(uint256(0xff))
         );
 
-    function layout() internal pure returns (Layout storage $) {
-        $ = layout(DEFAULT_STORAGE_SLOT);
+    function ref() internal pure returns (Layout storage $) {
+        $ = ref(DEFAULT_STORAGE_SLOT);
     }
 
-    function layout(sslot slot) internal pure returns (Layout storage $) {
+    function ref(sslot slot) internal pure returns (Layout storage $) {
         assembly {
             $.slot := slot
         }

--- a/contracts/token/common/royalty/_NFTRoyalty.sol
+++ b/contracts/token/common/royalty/_NFTRoyalty.sol
@@ -40,7 +40,7 @@ abstract contract _NFTRoyalty is _INFTRoyalty, _Introspectable {
     function _getRoyaltyBPS(
         uint256 tokenId
     ) internal view virtual returns (uint16 royaltyBPS) {
-        ERC2981Storage.Layout storage $ = ERC2981Storage.layout(
+        ERC2981Storage.Layout storage $ = ERC2981Storage.ref(
             ERC2981Storage.DEFAULT_STORAGE_SLOT
         );
         royaltyBPS = $.royaltiesBPS[tokenId];
@@ -59,7 +59,7 @@ abstract contract _NFTRoyalty is _INFTRoyalty, _Introspectable {
     function _getRoyaltyReceiver(
         uint256 tokenId
     ) internal view virtual returns (address royaltyReceiver) {
-        ERC2981Storage.Layout storage $ = ERC2981Storage.layout(
+        ERC2981Storage.Layout storage $ = ERC2981Storage.ref(
             ERC2981Storage.DEFAULT_STORAGE_SLOT
         );
         royaltyReceiver = $.royaltyReceivers[tokenId];
@@ -76,7 +76,7 @@ abstract contract _NFTRoyalty is _INFTRoyalty, _Introspectable {
      */
     function _setRoyaltyBPS(uint256 tokenId, uint16 royaltyBPS) internal {
         if (royaltyBPS > MAX_ROYALTY) revert NFTRoyalty__RoyaltyTooHigh();
-        ERC2981Storage.layout(ERC2981Storage.DEFAULT_STORAGE_SLOT).royaltiesBPS[
+        ERC2981Storage.ref(ERC2981Storage.DEFAULT_STORAGE_SLOT).royaltiesBPS[
             tokenId
         ] = royaltyBPS;
     }
@@ -89,7 +89,7 @@ abstract contract _NFTRoyalty is _INFTRoyalty, _Introspectable {
         if (defaultRoyaltyBPS > MAX_ROYALTY)
             revert NFTRoyalty__RoyaltyTooHigh();
         ERC2981Storage
-            .layout(ERC2981Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC2981Storage.DEFAULT_STORAGE_SLOT)
             .defaultRoyaltyBPS = defaultRoyaltyBPS;
     }
 
@@ -100,7 +100,7 @@ abstract contract _NFTRoyalty is _INFTRoyalty, _Introspectable {
      */
     function _setRoyaltyReceiver(uint256 tokenId, address receiver) internal {
         ERC2981Storage
-            .layout(ERC2981Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC2981Storage.DEFAULT_STORAGE_SLOT)
             .royaltyReceivers[tokenId] = receiver;
     }
 
@@ -110,7 +110,7 @@ abstract contract _NFTRoyalty is _INFTRoyalty, _Introspectable {
      */
     function _setDefaultRoyaltyReceiver(address defaultReceiver) internal {
         ERC2981Storage
-            .layout(ERC2981Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC2981Storage.DEFAULT_STORAGE_SLOT)
             .defaultRoyaltyReceiver = defaultReceiver;
     }
 }

--- a/contracts/token/fungible/_FungibleToken.sol
+++ b/contracts/token/fungible/_FungibleToken.sol
@@ -16,7 +16,7 @@ abstract contract _FungibleToken is _IFungibleToken, _Context {
      */
     function _totalSupply() internal view virtual returns (uint256) {
         return
-            ERC20Storage.layout(ERC20Storage.DEFAULT_STORAGE_SLOT).totalSupply;
+            ERC20Storage.ref(ERC20Storage.DEFAULT_STORAGE_SLOT).totalSupply;
     }
 
     /**
@@ -28,7 +28,7 @@ abstract contract _FungibleToken is _IFungibleToken, _Context {
         address account
     ) internal view virtual returns (uint256) {
         return
-            ERC20Storage.layout(ERC20Storage.DEFAULT_STORAGE_SLOT).balances[
+            ERC20Storage.ref(ERC20Storage.DEFAULT_STORAGE_SLOT).balances[
                 account
             ];
     }
@@ -44,7 +44,7 @@ abstract contract _FungibleToken is _IFungibleToken, _Context {
         address spender
     ) internal view virtual returns (uint256) {
         return
-            ERC20Storage.layout(ERC20Storage.DEFAULT_STORAGE_SLOT).allowances[
+            ERC20Storage.ref(ERC20Storage.DEFAULT_STORAGE_SLOT).allowances[
                 holder
             ][spender];
     }
@@ -69,7 +69,7 @@ abstract contract _FungibleToken is _IFungibleToken, _Context {
             revert FungibleToken__ApproveFromZeroAddress();
         if (spender == address(0)) revert FungibleToken__ApproveToZeroAddress();
 
-        ERC20Storage.layout(ERC20Storage.DEFAULT_STORAGE_SLOT).allowances[
+        ERC20Storage.ref(ERC20Storage.DEFAULT_STORAGE_SLOT).allowances[
             holder
         ][spender] = amount;
 
@@ -108,7 +108,7 @@ abstract contract _FungibleToken is _IFungibleToken, _Context {
 
         _beforeTokenTransfer(address(0), account, amount);
 
-        ERC20Storage.Layout storage $ = ERC20Storage.layout(
+        ERC20Storage.Layout storage $ = ERC20Storage.ref(
             ERC20Storage.DEFAULT_STORAGE_SLOT
         );
         $.totalSupply += amount;
@@ -127,7 +127,7 @@ abstract contract _FungibleToken is _IFungibleToken, _Context {
 
         _beforeTokenTransfer(account, address(0), amount);
 
-        ERC20Storage.Layout storage $ = ERC20Storage.layout(
+        ERC20Storage.Layout storage $ = ERC20Storage.ref(
             ERC20Storage.DEFAULT_STORAGE_SLOT
         );
         uint256 balance = $.balances[account];
@@ -166,7 +166,7 @@ abstract contract _FungibleToken is _IFungibleToken, _Context {
 
         _beforeTokenTransfer(holder, recipient, amount);
 
-        ERC20Storage.Layout storage $ = ERC20Storage.layout(
+        ERC20Storage.Layout storage $ = ERC20Storage.ref(
             ERC20Storage.DEFAULT_STORAGE_SLOT
         );
         uint256 holderBalance = $.balances[holder];

--- a/contracts/token/fungible/metadata/_FungibleTokenMetadata.sol
+++ b/contracts/token/fungible/metadata/_FungibleTokenMetadata.sol
@@ -14,7 +14,7 @@ abstract contract _FungibleTokenMetadata is _IFungibleTokenMetadata {
      * @return token name
      */
     function _name() internal view virtual returns (string memory) {
-        return ERC20Storage.layout(ERC20Storage.DEFAULT_STORAGE_SLOT).name;
+        return ERC20Storage.ref(ERC20Storage.DEFAULT_STORAGE_SLOT).name;
     }
 
     /**
@@ -22,7 +22,7 @@ abstract contract _FungibleTokenMetadata is _IFungibleTokenMetadata {
      * @return token symbol
      */
     function _symbol() internal view virtual returns (string memory) {
-        return ERC20Storage.layout(ERC20Storage.DEFAULT_STORAGE_SLOT).symbol;
+        return ERC20Storage.ref(ERC20Storage.DEFAULT_STORAGE_SLOT).symbol;
     }
 
     /**
@@ -30,20 +30,20 @@ abstract contract _FungibleTokenMetadata is _IFungibleTokenMetadata {
      * @return token decimals
      */
     function _decimals() internal view virtual returns (uint8) {
-        return ERC20Storage.layout(ERC20Storage.DEFAULT_STORAGE_SLOT).decimals;
+        return ERC20Storage.ref(ERC20Storage.DEFAULT_STORAGE_SLOT).decimals;
     }
 
     function _setName(string memory name) internal virtual {
-        ERC20Storage.layout(ERC20Storage.DEFAULT_STORAGE_SLOT).name = name;
+        ERC20Storage.ref(ERC20Storage.DEFAULT_STORAGE_SLOT).name = name;
     }
 
     function _setSymbol(string memory symbol) internal virtual {
-        ERC20Storage.layout(ERC20Storage.DEFAULT_STORAGE_SLOT).symbol = symbol;
+        ERC20Storage.ref(ERC20Storage.DEFAULT_STORAGE_SLOT).symbol = symbol;
     }
 
     function _setDecimals(uint8 decimals) internal virtual {
         ERC20Storage
-            .layout(ERC20Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC20Storage.DEFAULT_STORAGE_SLOT)
             .decimals = decimals;
     }
 }

--- a/contracts/token/fungible/permit/_FungibleTokenPermit.sol
+++ b/contracts/token/fungible/permit/_FungibleTokenPermit.sol
@@ -48,7 +48,7 @@ abstract contract _FungibleTokenPermit is
     function _nonces(address owner) internal view virtual returns (uint256) {
         return
             ERC20Storage
-                .layout(ERC20Storage.DEFAULT_STORAGE_SLOT)
+                .ref(ERC20Storage.DEFAULT_STORAGE_SLOT)
                 .erc2612Nonces[owner];
     }
 
@@ -118,7 +118,7 @@ abstract contract _FungibleTokenPermit is
             revert FungibleTokenPermit__ExpiredDeadline();
 
         uint256 nonce = ERC20Storage
-            .layout(ERC20Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC20Storage.DEFAULT_STORAGE_SLOT)
             .erc2612Nonces[owner]++;
 
         // execute EIP-712 hashStruct procedure

--- a/contracts/token/fungible/restricted/_RestrictedFungibleToken.sol
+++ b/contracts/token/fungible/restricted/_RestrictedFungibleToken.sol
@@ -27,7 +27,7 @@ abstract contract _RestrictedFungibleToken is
 
         mapping(uint8 restrictionCode => string restrictionMessage)
             storage restrictions = ERC20Storage
-                .layout(ERC20Storage.DEFAULT_STORAGE_SLOT)
+                .ref(ERC20Storage.DEFAULT_STORAGE_SLOT)
                 .erc1404RestrictionMessages;
 
         unchecked {
@@ -65,7 +65,7 @@ abstract contract _RestrictedFungibleToken is
         uint8 restrictionCode
     ) internal view virtual returns (string memory message) {
         message = ERC20Storage
-            .layout(ERC20Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC20Storage.DEFAULT_STORAGE_SLOT)
             .erc1404RestrictionMessages[restrictionCode];
     }
 

--- a/contracts/token/fungible/snapshot/_FungibleTokenSnapshot.sol
+++ b/contracts/token/fungible/snapshot/_FungibleTokenSnapshot.sol
@@ -29,7 +29,7 @@ abstract contract _FungibleTokenSnapshot is
         (bool snapshotted, uint256 value) = _valueAt(
             snapshotId,
             ERC20Storage
-                .layout(ERC20Storage.DEFAULT_STORAGE_SLOT)
+                .ref(ERC20Storage.DEFAULT_STORAGE_SLOT)
                 .accountBalanceSnapshots[account]
         );
         return snapshotted ? value : _balanceOf(account);
@@ -46,14 +46,14 @@ abstract contract _FungibleTokenSnapshot is
         (bool snapshotted, uint256 value) = _valueAt(
             snapshotId,
             ERC20Storage
-                .layout(ERC20Storage.DEFAULT_STORAGE_SLOT)
+                .ref(ERC20Storage.DEFAULT_STORAGE_SLOT)
                 .totalSupplySnapshots
         );
         return snapshotted ? value : _totalSupply();
     }
 
     function _snapshot() internal virtual returns (uint256) {
-        ERC20Storage.Layout storage $ = ERC20Storage.layout(
+        ERC20Storage.Layout storage $ = ERC20Storage.ref(
             ERC20Storage.DEFAULT_STORAGE_SLOT
         );
 
@@ -67,7 +67,7 @@ abstract contract _FungibleTokenSnapshot is
     function _updateAccountSnapshot(address account) private {
         _updateSnapshot(
             ERC20Storage
-                .layout(ERC20Storage.DEFAULT_STORAGE_SLOT)
+                .ref(ERC20Storage.DEFAULT_STORAGE_SLOT)
                 .accountBalanceSnapshots[account],
             _balanceOf(account)
         );
@@ -76,7 +76,7 @@ abstract contract _FungibleTokenSnapshot is
     function _updateTotalSupplySnapshot() private {
         _updateSnapshot(
             ERC20Storage
-                .layout(ERC20Storage.DEFAULT_STORAGE_SLOT)
+                .ref(ERC20Storage.DEFAULT_STORAGE_SLOT)
                 .totalSupplySnapshots,
             _totalSupply()
         );
@@ -87,7 +87,7 @@ abstract contract _FungibleTokenSnapshot is
         uint256 value
     ) private {
         uint256 current = ERC20Storage
-            .layout(ERC20Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC20Storage.DEFAULT_STORAGE_SLOT)
             .snapshotId;
 
         if (_lastSnapshotId(snapshots.ids) < current) {
@@ -130,7 +130,7 @@ abstract contract _FungibleTokenSnapshot is
         ERC20Storage.Snapshots storage snapshots
     ) private view returns (bool snapshotted, uint256 value) {
         if (snapshotId == 0) revert FungibleTokenSnapshot__SnapshotIdIsZero();
-        ERC20Storage.Layout storage $ = ERC20Storage.layout(
+        ERC20Storage.Layout storage $ = ERC20Storage.ref(
             ERC20Storage.DEFAULT_STORAGE_SLOT
         );
 

--- a/contracts/token/fungible/vault/_FungibleVaultToken.sol
+++ b/contracts/token/fungible/vault/_FungibleVaultToken.sol
@@ -25,7 +25,7 @@ abstract contract _FungibleVaultToken is
      */
     function _asset() internal view virtual returns (address asset) {
         asset = ERC20Storage
-            .layout(ERC20Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC20Storage.DEFAULT_STORAGE_SLOT)
             .erc4626Asset;
     }
 
@@ -392,7 +392,7 @@ abstract contract _FungibleVaultToken is
      */
     function _setAsset(address asset) internal virtual {
         ERC20Storage
-            .layout(ERC20Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC20Storage.DEFAULT_STORAGE_SLOT)
             .erc4626Asset = asset;
     }
 }

--- a/contracts/token/multi/_MultiToken.sol
+++ b/contracts/token/multi/_MultiToken.sol
@@ -28,7 +28,7 @@ abstract contract _MultiToken is _IMultiToken, _Introspectable, _Context {
     ) internal view virtual returns (uint256) {
         if (account == address(0)) revert MultiToken__BalanceQueryZeroAddress();
         return
-            ERC1155Storage.layout(ERC1155Storage.DEFAULT_STORAGE_SLOT).balances[
+            ERC1155Storage.ref(ERC1155Storage.DEFAULT_STORAGE_SLOT).balances[
                 id
             ][account];
     }
@@ -48,7 +48,7 @@ abstract contract _MultiToken is _IMultiToken, _Introspectable, _Context {
 
         mapping(uint256 tokenId => mapping(address account => uint256 balance))
             storage balances = ERC1155Storage
-                .layout(ERC1155Storage.DEFAULT_STORAGE_SLOT)
+                .ref(ERC1155Storage.DEFAULT_STORAGE_SLOT)
                 .balances;
 
         uint256[] memory batchBalances = new uint256[](accounts.length);
@@ -76,7 +76,7 @@ abstract contract _MultiToken is _IMultiToken, _Introspectable, _Context {
     ) internal view virtual returns (bool) {
         return
             ERC1155Storage
-                .layout(ERC1155Storage.DEFAULT_STORAGE_SLOT)
+                .ref(ERC1155Storage.DEFAULT_STORAGE_SLOT)
                 .operatorApprovals[account][operator];
     }
 
@@ -86,7 +86,7 @@ abstract contract _MultiToken is _IMultiToken, _Introspectable, _Context {
     ) internal virtual {
         if (_msgSender() == operator) revert MultiToken__SelfApproval();
         ERC1155Storage
-            .layout(ERC1155Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC1155Storage.DEFAULT_STORAGE_SLOT)
             .operatorApprovals[_msgSender()][operator] = status;
         emit ApprovalForAll(_msgSender(), operator, status);
     }
@@ -116,7 +116,7 @@ abstract contract _MultiToken is _IMultiToken, _Introspectable, _Context {
             data
         );
 
-        ERC1155Storage.layout(ERC1155Storage.DEFAULT_STORAGE_SLOT).balances[id][
+        ERC1155Storage.ref(ERC1155Storage.DEFAULT_STORAGE_SLOT).balances[id][
             account
         ] += amount;
 
@@ -177,7 +177,7 @@ abstract contract _MultiToken is _IMultiToken, _Introspectable, _Context {
 
         mapping(uint256 tokenId => mapping(address account => uint256 balance))
             storage balances = ERC1155Storage
-                .layout(ERC1155Storage.DEFAULT_STORAGE_SLOT)
+                .ref(ERC1155Storage.DEFAULT_STORAGE_SLOT)
                 .balances;
 
         for (uint256 i; i < ids.length; ) {
@@ -239,7 +239,7 @@ abstract contract _MultiToken is _IMultiToken, _Introspectable, _Context {
 
         mapping(address account => uint256 balance)
             storage balances = ERC1155Storage
-                .layout(ERC1155Storage.DEFAULT_STORAGE_SLOT)
+                .ref(ERC1155Storage.DEFAULT_STORAGE_SLOT)
                 .balances[id];
 
         unchecked {
@@ -277,7 +277,7 @@ abstract contract _MultiToken is _IMultiToken, _Introspectable, _Context {
 
         mapping(uint256 tokenId => mapping(address account => uint256 balance))
             storage balances = ERC1155Storage
-                .layout(ERC1155Storage.DEFAULT_STORAGE_SLOT)
+                .ref(ERC1155Storage.DEFAULT_STORAGE_SLOT)
                 .balances;
 
         unchecked {
@@ -347,7 +347,7 @@ abstract contract _MultiToken is _IMultiToken, _Introspectable, _Context {
 
         mapping(uint256 tokenId => mapping(address account => uint256 balance))
             storage balances = ERC1155Storage
-                .layout(ERC1155Storage.DEFAULT_STORAGE_SLOT)
+                .ref(ERC1155Storage.DEFAULT_STORAGE_SLOT)
                 .balances;
 
         unchecked {
@@ -417,7 +417,7 @@ abstract contract _MultiToken is _IMultiToken, _Introspectable, _Context {
 
         mapping(uint256 tokenId => mapping(address account => uint256 balance))
             storage balances = ERC1155Storage
-                .layout(ERC1155Storage.DEFAULT_STORAGE_SLOT)
+                .ref(ERC1155Storage.DEFAULT_STORAGE_SLOT)
                 .balances;
 
         for (uint256 i; i < ids.length; ) {

--- a/contracts/token/multi/enumerable/_MultiTokenEnumerable.sol
+++ b/contracts/token/multi/enumerable/_MultiTokenEnumerable.sol
@@ -55,7 +55,7 @@ abstract contract _MultiTokenEnumerable is _IMultiTokenEnumerable, _MultiToken {
 
         unchecked {
             for (uint256 i; i < accounts.length(); i++) {
-                addresses[i] = accounts.at(i);
+                addresses[i] = accounts.valueAt(i);
             }
         }
 
@@ -78,7 +78,7 @@ abstract contract _MultiTokenEnumerable is _IMultiTokenEnumerable, _MultiToken {
 
         unchecked {
             for (uint256 i; i < tokens.length(); i++) {
-                ids[i] = tokens.at(i);
+                ids[i] = tokens.valueAt(i);
             }
         }
 

--- a/contracts/token/multi/enumerable/_MultiTokenEnumerable.sol
+++ b/contracts/token/multi/enumerable/_MultiTokenEnumerable.sol
@@ -22,7 +22,7 @@ abstract contract _MultiTokenEnumerable is _IMultiTokenEnumerable, _MultiToken {
     function _totalSupply(uint256 id) internal view virtual returns (uint256) {
         return
             ERC1155Storage
-                .layout(ERC1155Storage.DEFAULT_STORAGE_SLOT)
+                .ref(ERC1155Storage.DEFAULT_STORAGE_SLOT)
                 .totalSupply[id];
     }
 
@@ -34,7 +34,7 @@ abstract contract _MultiTokenEnumerable is _IMultiTokenEnumerable, _MultiToken {
     function _totalHolders(uint256 id) internal view virtual returns (uint256) {
         return
             ERC1155Storage
-                .layout(ERC1155Storage.DEFAULT_STORAGE_SLOT)
+                .ref(ERC1155Storage.DEFAULT_STORAGE_SLOT)
                 .accountsByToken[id]
                 .length();
     }
@@ -48,7 +48,7 @@ abstract contract _MultiTokenEnumerable is _IMultiTokenEnumerable, _MultiToken {
         uint256 id
     ) internal view virtual returns (address[] memory) {
         EnumerableSet.AddressSet storage accounts = ERC1155Storage
-            .layout(ERC1155Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC1155Storage.DEFAULT_STORAGE_SLOT)
             .accountsByToken[id];
 
         address[] memory addresses = new address[](accounts.length());
@@ -71,7 +71,7 @@ abstract contract _MultiTokenEnumerable is _IMultiTokenEnumerable, _MultiToken {
         address account
     ) internal view virtual returns (uint256[] memory) {
         EnumerableSet.UintSet storage tokens = ERC1155Storage
-            .layout(ERC1155Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC1155Storage.DEFAULT_STORAGE_SLOT)
             .tokensByAccount[account];
 
         uint256[] memory ids = new uint256[](tokens.length());
@@ -100,7 +100,7 @@ abstract contract _MultiTokenEnumerable is _IMultiTokenEnumerable, _MultiToken {
         super._beforeTokenTransfer(operator, from, to, ids, amounts, data);
 
         if (from != to) {
-            ERC1155Storage.Layout storage $ = ERC1155Storage.layout(
+            ERC1155Storage.Layout storage $ = ERC1155Storage.ref(
                 ERC1155Storage.DEFAULT_STORAGE_SLOT
             );
             mapping(uint256 tokenId => EnumerableSet.AddressSet holders)

--- a/contracts/token/multi/metadata/_MultiTokenMetadata.sol
+++ b/contracts/token/multi/metadata/_MultiTokenMetadata.sol
@@ -15,7 +15,7 @@ abstract contract _MultiTokenMetadata is _IMultiTokenMetadata {
     function _uri(
         uint256 tokenId
     ) internal view virtual returns (string memory) {
-        ERC1155Storage.Layout storage $ = ERC1155Storage.layout(
+        ERC1155Storage.Layout storage $ = ERC1155Storage.ref(
             ERC1155Storage.DEFAULT_STORAGE_SLOT
         );
 
@@ -52,7 +52,7 @@ abstract contract _MultiTokenMetadata is _IMultiTokenMetadata {
      */
     function _setBaseURI(string memory baseURI) internal {
         ERC1155Storage
-            .layout(ERC1155Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC1155Storage.DEFAULT_STORAGE_SLOT)
             .baseURI = baseURI;
     }
 
@@ -62,7 +62,7 @@ abstract contract _MultiTokenMetadata is _IMultiTokenMetadata {
      * @param tokenURI per-token URI
      */
     function _setTokenURI(uint256 tokenId, string memory tokenURI) internal {
-        ERC1155Storage.layout(ERC1155Storage.DEFAULT_STORAGE_SLOT).tokenURIs[
+        ERC1155Storage.ref(ERC1155Storage.DEFAULT_STORAGE_SLOT).tokenURIs[
             tokenId
         ] = tokenURI;
         emit URI(tokenURI, tokenId);

--- a/contracts/token/non_fungible/_NonFungibleToken.sol
+++ b/contracts/token/non_fungible/_NonFungibleToken.sol
@@ -30,14 +30,14 @@ abstract contract _NonFungibleToken is
             revert NonFungibleToken__BalanceQueryZeroAddress();
         return
             ERC721Storage
-                .layout(ERC721Storage.DEFAULT_STORAGE_SLOT)
+                .ref(ERC721Storage.DEFAULT_STORAGE_SLOT)
                 .holderTokens[account]
                 .length();
     }
 
     function _ownerOf(uint256 tokenId) internal view virtual returns (address) {
         address owner = ERC721Storage
-            .layout(ERC721Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC721Storage.DEFAULT_STORAGE_SLOT)
             .tokenOwners
             .get(tokenId);
         if (owner == address(0)) revert NonFungibleToken__InvalidOwner();
@@ -47,7 +47,7 @@ abstract contract _NonFungibleToken is
     function _exists(uint256 tokenId) internal view virtual returns (bool) {
         return
             ERC721Storage
-                .layout(ERC721Storage.DEFAULT_STORAGE_SLOT)
+                .ref(ERC721Storage.DEFAULT_STORAGE_SLOT)
                 .tokenOwners
                 .contains(tokenId);
     }
@@ -59,7 +59,7 @@ abstract contract _NonFungibleToken is
 
         return
             ERC721Storage
-                .layout(ERC721Storage.DEFAULT_STORAGE_SLOT)
+                .ref(ERC721Storage.DEFAULT_STORAGE_SLOT)
                 .tokenApprovals[tokenId];
     }
 
@@ -69,7 +69,7 @@ abstract contract _NonFungibleToken is
     ) internal view virtual returns (bool) {
         return
             ERC721Storage
-                .layout(ERC721Storage.DEFAULT_STORAGE_SLOT)
+                .ref(ERC721Storage.DEFAULT_STORAGE_SLOT)
                 .operatorApprovals[account][operator];
     }
 
@@ -92,7 +92,7 @@ abstract contract _NonFungibleToken is
 
         _beforeTokenTransfer(address(0), to, tokenId);
 
-        ERC721Storage.Layout storage $ = ERC721Storage.layout(
+        ERC721Storage.Layout storage $ = ERC721Storage.ref(
             ERC721Storage.DEFAULT_STORAGE_SLOT
         );
 
@@ -121,7 +121,7 @@ abstract contract _NonFungibleToken is
 
         _beforeTokenTransfer(owner, address(0), tokenId);
 
-        ERC721Storage.Layout storage $ = ERC721Storage.layout(
+        ERC721Storage.Layout storage $ = ERC721Storage.ref(
             ERC721Storage.DEFAULT_STORAGE_SLOT
         );
 
@@ -146,7 +146,7 @@ abstract contract _NonFungibleToken is
 
         _beforeTokenTransfer(from, to, tokenId);
 
-        ERC721Storage.Layout storage $ = ERC721Storage.layout(
+        ERC721Storage.Layout storage $ = ERC721Storage.ref(
             ERC721Storage.DEFAULT_STORAGE_SLOT
         );
 
@@ -210,7 +210,7 @@ abstract contract _NonFungibleToken is
         if (_msgSender() != owner && !_isApprovedForAll(owner, _msgSender()))
             revert NonFungibleToken__NotOwnerOrApproved();
 
-        ERC721Storage.layout(ERC721Storage.DEFAULT_STORAGE_SLOT).tokenApprovals[
+        ERC721Storage.ref(ERC721Storage.DEFAULT_STORAGE_SLOT).tokenApprovals[
             tokenId
         ] = operator;
         emit Approval(owner, operator, tokenId);
@@ -222,7 +222,7 @@ abstract contract _NonFungibleToken is
     ) internal virtual {
         if (operator == _msgSender()) revert NonFungibleToken__SelfApproval();
         ERC721Storage
-            .layout(ERC721Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC721Storage.DEFAULT_STORAGE_SLOT)
             .operatorApprovals[_msgSender()][operator] = status;
         emit ApprovalForAll(_msgSender(), operator, status);
     }

--- a/contracts/token/non_fungible/enumerable/_NonFungibleTokenEnumerable.sol
+++ b/contracts/token/non_fungible/enumerable/_NonFungibleTokenEnumerable.sol
@@ -37,7 +37,7 @@ abstract contract _NonFungibleTokenEnumerable is
             ERC721Storage
                 .layout(ERC721Storage.DEFAULT_STORAGE_SLOT)
                 .holderTokens[owner]
-                .at(index);
+                .valueAt(index);
     }
 
     /**
@@ -49,6 +49,6 @@ abstract contract _NonFungibleTokenEnumerable is
         (tokenId, ) = ERC721Storage
             .layout(ERC721Storage.DEFAULT_STORAGE_SLOT)
             .tokenOwners
-            .at(index);
+            .valueAt(index);
     }
 }

--- a/contracts/token/non_fungible/enumerable/_NonFungibleTokenEnumerable.sol
+++ b/contracts/token/non_fungible/enumerable/_NonFungibleTokenEnumerable.sol
@@ -21,7 +21,7 @@ abstract contract _NonFungibleTokenEnumerable is
     function _totalSupply() internal view returns (uint256) {
         return
             ERC721Storage
-                .layout(ERC721Storage.DEFAULT_STORAGE_SLOT)
+                .ref(ERC721Storage.DEFAULT_STORAGE_SLOT)
                 .tokenOwners
                 .length();
     }
@@ -35,7 +35,7 @@ abstract contract _NonFungibleTokenEnumerable is
     ) internal view returns (uint256) {
         return
             ERC721Storage
-                .layout(ERC721Storage.DEFAULT_STORAGE_SLOT)
+                .ref(ERC721Storage.DEFAULT_STORAGE_SLOT)
                 .holderTokens[owner]
                 .valueAt(index);
     }
@@ -47,7 +47,7 @@ abstract contract _NonFungibleTokenEnumerable is
         uint256 index
     ) internal view returns (uint256 tokenId) {
         (tokenId, ) = ERC721Storage
-            .layout(ERC721Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC721Storage.DEFAULT_STORAGE_SLOT)
             .tokenOwners
             .valueAt(index);
     }

--- a/contracts/token/non_fungible/metadata/_NonFungibleTokenMetadata.sol
+++ b/contracts/token/non_fungible/metadata/_NonFungibleTokenMetadata.sol
@@ -21,7 +21,7 @@ abstract contract _NonFungibleTokenMetadata is
      * @return name token name
      */
     function _name() internal view virtual returns (string memory name) {
-        name = ERC721Storage.layout(ERC721Storage.DEFAULT_STORAGE_SLOT).name;
+        name = ERC721Storage.ref(ERC721Storage.DEFAULT_STORAGE_SLOT).name;
     }
 
     /**
@@ -30,7 +30,7 @@ abstract contract _NonFungibleTokenMetadata is
      */
     function _symbol() internal view virtual returns (string memory symbol) {
         symbol = ERC721Storage
-            .layout(ERC721Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC721Storage.DEFAULT_STORAGE_SLOT)
             .symbol;
     }
 
@@ -44,7 +44,7 @@ abstract contract _NonFungibleTokenMetadata is
         if (!_exists(tokenId))
             revert NonFungibleTokenMetadata__NonExistentToken();
 
-        ERC721Storage.Layout storage $ = ERC721Storage.layout(
+        ERC721Storage.Layout storage $ = ERC721Storage.ref(
             ERC721Storage.DEFAULT_STORAGE_SLOT
         );
 
@@ -79,7 +79,7 @@ abstract contract _NonFungibleTokenMetadata is
      * @param name token name
      */
     function _setName(string memory name) internal virtual {
-        ERC721Storage.layout(ERC721Storage.DEFAULT_STORAGE_SLOT).name = name;
+        ERC721Storage.ref(ERC721Storage.DEFAULT_STORAGE_SLOT).name = name;
     }
 
     /**
@@ -88,7 +88,7 @@ abstract contract _NonFungibleTokenMetadata is
      */
     function _setSymbol(string memory symbol) internal virtual {
         ERC721Storage
-            .layout(ERC721Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC721Storage.DEFAULT_STORAGE_SLOT)
             .symbol = symbol;
     }
 
@@ -101,7 +101,7 @@ abstract contract _NonFungibleTokenMetadata is
         uint256 tokenId,
         string memory tokenURI
     ) internal virtual {
-        ERC721Storage.layout(ERC721Storage.DEFAULT_STORAGE_SLOT).tokenURIs[
+        ERC721Storage.ref(ERC721Storage.DEFAULT_STORAGE_SLOT).tokenURIs[
             tokenId
         ] = tokenURI;
     }
@@ -112,7 +112,7 @@ abstract contract _NonFungibleTokenMetadata is
      */
     function _setBaseURI(string memory baseURI) internal virtual {
         ERC721Storage
-            .layout(ERC721Storage.DEFAULT_STORAGE_SLOT)
+            .ref(ERC721Storage.DEFAULT_STORAGE_SLOT)
             .baseURI = baseURI;
     }
 
@@ -129,7 +129,7 @@ abstract contract _NonFungibleTokenMetadata is
 
         if (to == address(0)) {
             delete ERC721Storage
-                .layout(ERC721Storage.DEFAULT_STORAGE_SLOT)
+                .ref(ERC721Storage.DEFAULT_STORAGE_SLOT)
                 .tokenURIs[tokenId];
         }
     }

--- a/contracts/utils/Address.sol
+++ b/contracts/utils/Address.sol
@@ -53,9 +53,9 @@ library Address {
     function functionCall(
         address target,
         bytes memory data,
-        bytes4 error
+        bytes4 errorSelector
     ) internal returns (bytes memory) {
-        return _functionCallWithValue(target, data, 0, error);
+        return _functionCallWithValue(target, data, 0, errorSelector);
     }
 
     function functionCallWithValue(
@@ -76,11 +76,11 @@ library Address {
         address target,
         bytes memory data,
         uint256 value,
-        bytes4 error
+        bytes4 errorSelector
     ) internal returns (bytes memory) {
         if (value > address(this).balance)
             revert Address__InsufficientBalance();
-        return _functionCallWithValue(target, data, value, error);
+        return _functionCallWithValue(target, data, value, errorSelector);
     }
 
     function functionDelegateCall(
@@ -98,10 +98,10 @@ library Address {
     function functionDelegateCall(
         address target,
         bytes memory data,
-        bytes4 error
+        bytes4 errorSelector
     ) internal returns (bytes memory) {
         (bool success, bytes memory returnData) = target.delegatecall(data);
-        _verifyCallResultFromTarget(target, success, returnData, error);
+        _verifyCallResultFromTarget(target, success, returnData, errorSelector);
         return returnData;
     }
 
@@ -156,12 +156,12 @@ library Address {
         address target,
         bytes memory data,
         uint256 value,
-        bytes4 error
+        bytes4 errorSelector
     ) private returns (bytes memory) {
         (bool success, bytes memory returnData) = target.call{ value: value }(
             data
         );
-        _verifyCallResultFromTarget(target, success, returnData, error);
+        _verifyCallResultFromTarget(target, success, returnData, errorSelector);
         return returnData;
     }
 
@@ -169,12 +169,12 @@ library Address {
         address target,
         bool success,
         bytes memory returnData,
-        bytes4 error
+        bytes4 errorSelector
     ) private view {
         if (!success) {
             if (returnData.length == 0) {
                 assembly {
-                    mstore(0, error)
+                    mstore(0, errorSelector)
                     revert(0, 4)
                 }
             } else {

--- a/test/data/EnumerableMap.ts
+++ b/test/data/EnumerableMap.ts
@@ -27,7 +27,7 @@ describe('EnumerableMap', () => {
       instance = await new $EnumerableMap__factory(deployer).deploy();
     });
 
-    describe('#at(uint256)', () => {
+    describe('#valueAt(uint256)', () => {
       it('returns value coresponding to index provided', async () => {
         await instance['$set(uint256,address,address)'](
           STORAGE_SLOT,
@@ -36,7 +36,7 @@ describe('EnumerableMap', () => {
         );
 
         const [key, value] =
-          await instance.$at_EnumerableMap_AddressToAddressMap.staticCall(
+          await instance.$valueAt_EnumerableMap_AddressToAddressMap.staticCall(
             STORAGE_SLOT,
             0n,
           );
@@ -48,7 +48,7 @@ describe('EnumerableMap', () => {
       describe('reverts if', () => {
         it('index is out of bounds', async () => {
           await expect(
-            instance.$at_EnumerableMap_AddressToAddressMap.staticCall(
+            instance.$valueAt_EnumerableMap_AddressToAddressMap.staticCall(
               STORAGE_SLOT,
               0n,
             ),
@@ -233,7 +233,7 @@ describe('EnumerableMap', () => {
           addressThree,
         );
         let [key, value] =
-          await instance.$at_EnumerableMap_AddressToAddressMap.staticCall(
+          await instance.$valueAt_EnumerableMap_AddressToAddressMap.staticCall(
             STORAGE_SLOT,
             0n,
           );
@@ -245,7 +245,7 @@ describe('EnumerableMap', () => {
           addressFour,
         );
         [key, value] =
-          await instance.$at_EnumerableMap_AddressToAddressMap.staticCall(
+          await instance.$valueAt_EnumerableMap_AddressToAddressMap.staticCall(
             STORAGE_SLOT,
             0n,
           );
@@ -486,7 +486,7 @@ describe('EnumerableMap', () => {
       instance = await new $EnumerableMap__factory(deployer).deploy();
     });
 
-    describe('#at(uint256)', () => {
+    describe('#valueAt(uint256)', () => {
       it('returns value coresponding to index provided', async () => {
         await instance['$set(uint256,uint256,address)'](
           STORAGE_SLOT,
@@ -495,7 +495,7 @@ describe('EnumerableMap', () => {
         );
 
         const [key, value] =
-          await instance.$at_EnumerableMap_UintToAddressMap.staticCall(
+          await instance.$valueAt_EnumerableMap_UintToAddressMap.staticCall(
             STORAGE_SLOT,
             0n,
           );
@@ -507,7 +507,7 @@ describe('EnumerableMap', () => {
       describe('reverts if', () => {
         it('index is out of bounds', async () => {
           await expect(
-            instance.$at_EnumerableMap_UintToAddressMap.staticCall(
+            instance.$valueAt_EnumerableMap_UintToAddressMap.staticCall(
               STORAGE_SLOT,
               0n,
             ),
@@ -689,7 +689,7 @@ describe('EnumerableMap', () => {
           addressThree,
         );
         let [key, value] =
-          await instance.$at_EnumerableMap_UintToAddressMap.staticCall(
+          await instance.$valueAt_EnumerableMap_UintToAddressMap.staticCall(
             STORAGE_SLOT,
             0n,
           );
@@ -701,7 +701,7 @@ describe('EnumerableMap', () => {
           addressTwo,
         );
         [key, value] =
-          await instance.$at_EnumerableMap_UintToAddressMap.staticCall(
+          await instance.$valueAt_EnumerableMap_UintToAddressMap.staticCall(
             STORAGE_SLOT,
             0n,
           );

--- a/test/data/EnumerableSet.ts
+++ b/test/data/EnumerableSet.ts
@@ -24,26 +24,26 @@ describe('EnumerableSet', async () => {
       instance = await new $EnumerableSet__factory(deployer).deploy();
     });
 
-    describe('#at(uint256)', () => {
+    describe('#valueAt(uint256)', () => {
       it('returns the value corresponding to index provided', async () => {
         await instance['$add(uint256,bytes32)'](STORAGE_SLOT, zeroBytes32);
         await instance['$add(uint256,bytes32)'](STORAGE_SLOT, oneBytes32);
         await instance['$add(uint256,bytes32)'](STORAGE_SLOT, twoBytes32);
 
         expect(
-          await instance.$at_EnumerableSet_Bytes32Set.staticCall(
+          await instance.$valueAt_EnumerableSet_Bytes32Set.staticCall(
             STORAGE_SLOT,
             0n,
           ),
         ).to.equal(zeroBytes32);
         expect(
-          await instance.$at_EnumerableSet_Bytes32Set.staticCall(
+          await instance.$valueAt_EnumerableSet_Bytes32Set.staticCall(
             STORAGE_SLOT,
             1n,
           ),
         ).to.equal(oneBytes32);
         expect(
-          await instance.$at_EnumerableSet_Bytes32Set.staticCall(
+          await instance.$valueAt_EnumerableSet_Bytes32Set.staticCall(
             STORAGE_SLOT,
             2n,
           ),
@@ -53,7 +53,7 @@ describe('EnumerableSet', async () => {
       describe('reverts if', () => {
         it('index out of bounds', async () => {
           await expect(
-            instance.$at_EnumerableSet_Bytes32Set.staticCall(STORAGE_SLOT, 0n),
+            instance.$valueAt_EnumerableSet_Bytes32Set.staticCall(STORAGE_SLOT, 0n),
           ).to.be.revertedWithCustomError(
             instance,
             'EnumerableSet__IndexOutOfBounds',
@@ -347,26 +347,26 @@ describe('EnumerableSet', async () => {
       instance = await new $EnumerableSet__factory(deployer).deploy();
     });
 
-    describe('#at(uint256)', () => {
+    describe('#valueAt(uint256)', () => {
       it('returns the value corresponding to index provided', async () => {
         await instance['$add(uint256,address)'](STORAGE_SLOT, zeroAddress);
         await instance['$add(uint256,address)'](STORAGE_SLOT, twoAddress);
         await instance['$add(uint256,address)'](STORAGE_SLOT, oneAddress);
 
         expect(
-          await instance.$at_EnumerableSet_AddressSet.staticCall(
+          await instance.$valueAt_EnumerableSet_AddressSet.staticCall(
             STORAGE_SLOT,
             0n,
           ),
         ).to.equal(zeroAddress);
         expect(
-          await instance.$at_EnumerableSet_AddressSet.staticCall(
+          await instance.$valueAt_EnumerableSet_AddressSet.staticCall(
             STORAGE_SLOT,
             1n,
           ),
         ).to.equal(twoAddress);
         expect(
-          await instance.$at_EnumerableSet_AddressSet.staticCall(
+          await instance.$valueAt_EnumerableSet_AddressSet.staticCall(
             STORAGE_SLOT,
             2n,
           ),
@@ -376,7 +376,7 @@ describe('EnumerableSet', async () => {
       describe('reverts if', () => {
         it('index out of bounds', async () => {
           await expect(
-            instance.$at_EnumerableSet_AddressSet.staticCall(STORAGE_SLOT, 0n),
+            instance.$valueAt_EnumerableSet_AddressSet.staticCall(STORAGE_SLOT, 0n),
           ).to.be.revertedWithCustomError(
             instance,
             'EnumerableSet__IndexOutOfBounds',
@@ -670,27 +670,27 @@ describe('EnumerableSet', async () => {
       instance = await new $EnumerableSet__factory(deployer).deploy();
     });
 
-    describe('#at(uint256)', () => {
+    describe('#valueAt(uint256)', () => {
       it('returns the value corresponding to index provided', async () => {
         await instance['$add(uint256,uint256)'](STORAGE_SLOT, zeroUint256);
         await instance['$add(uint256,uint256)'](STORAGE_SLOT, twoUint256);
         await instance['$add(uint256,uint256)'](STORAGE_SLOT, oneUint256);
 
         expect(
-          await instance.$at_EnumerableSet_UintSet.staticCall(STORAGE_SLOT, 0n),
+          await instance.$valueAt_EnumerableSet_UintSet.staticCall(STORAGE_SLOT, 0n),
         ).to.equal(zeroUint256);
         expect(
-          await instance.$at_EnumerableSet_UintSet.staticCall(STORAGE_SLOT, 1n),
+          await instance.$valueAt_EnumerableSet_UintSet.staticCall(STORAGE_SLOT, 1n),
         ).to.equal(twoUint256);
         expect(
-          await instance.$at_EnumerableSet_UintSet.staticCall(STORAGE_SLOT, 2n),
+          await instance.$valueAt_EnumerableSet_UintSet.staticCall(STORAGE_SLOT, 2n),
         ).to.equal(oneUint256);
       });
 
       describe('reverts if', () => {
         it('index out of bounds', async () => {
           await expect(
-            instance.$at_EnumerableSet_UintSet.staticCall(STORAGE_SLOT, 0n),
+            instance.$valueAt_EnumerableSet_UintSet.staticCall(STORAGE_SLOT, 0n),
           ).to.be.revertedWithCustomError(
             instance,
             'EnumerableSet__IndexOutOfBounds',

--- a/test/data/MerkleTree.ts
+++ b/test/data/MerkleTree.ts
@@ -137,19 +137,19 @@ describe('MerkleTree', () => {
     });
   });
 
-  describe('#at', () => {
+  describe('#valueAt', () => {
     it('returns element at given index', async () => {
       const hash = randomHash();
 
       await instance.$push(STORAGE_SLOT, hash);
 
-      expect(await instance.$at.staticCall(STORAGE_SLOT, 0)).to.equal(hash);
+      expect(await instance.$valueAt.staticCall(STORAGE_SLOT, 0)).to.equal(hash);
     });
 
     describe('reverts if', () => {
       it('tree is size zero', async () => {
         await expect(
-          instance.$at.staticCall(STORAGE_SLOT, 0),
+          instance.$valueAt.staticCall(STORAGE_SLOT, 0),
         ).to.be.revertedWithPanic(PANIC_CODES.ARRAY_ACCESS_OUT_OF_BOUNDS);
       });
 
@@ -157,7 +157,7 @@ describe('MerkleTree', () => {
         await instance.$push(STORAGE_SLOT, randomHash());
 
         await expect(
-          instance.$at.staticCall(STORAGE_SLOT, 1),
+          instance.$valueAt.staticCall(STORAGE_SLOT, 1),
         ).to.be.revertedWithPanic(PANIC_CODES.ARRAY_ACCESS_OUT_OF_BOUNDS);
       });
     });


### PR DESCRIPTION
The following deprecated keywords have been changed:
* `at` -> `valueAt`
* `error` -> `errorSelector`
* `layout` -> `ref`

The `virtual` keyword has been removed from a modifier.

These are unavoidable breaking changes.